### PR TITLE
fix: prevent stale check-in data by adding date filters and normalizing audit log types

### DIFF
--- a/backend-elysia/src/modules/activity-check-in/index.ts
+++ b/backend-elysia/src/modules/activity-check-in/index.ts
@@ -28,12 +28,13 @@ export const activityCheckIn = new Elysia({ prefix: "/activity-check-in" })
 			)
 			.get(
 				"/teacher/:teacherId/classroom/:classroomId",
-				async ({ params: { teacherId, classroomId } }) => {
-					return ActivityCheckInService.getByTeacherAndClassroom(teacherId, classroomId);
+				async ({ params: { teacherId, classroomId }, query }) => {
+					return ActivityCheckInService.getByTeacherAndClassroom(teacherId, classroomId, query.date);
 				},
 				{
+					query: ActivityCheckInModel.teacherClassroomQuery,
 					detail: {
-						summary: "Get activity check-in by teacher and classroom",
+						summary: "Get activity check-in by teacher and classroom (filter by ?date=YYYY-MM-DD)",
 					},
 				},
 			)

--- a/backend-elysia/src/modules/activity-check-in/model.ts
+++ b/backend-elysia/src/modules/activity-check-in/model.ts
@@ -1,6 +1,9 @@
 import { t, type UnwrapSchema } from "elysia";
 
 export const ActivityCheckInModel = {
+	teacherClassroomQuery: t.Object({
+		date: t.Optional(t.String({ description: "Filter by date YYYY-MM-DD" })),
+	}),
 	activityBody: t.Object({
 		teacherId: t.String(),
 		classroomId: t.String(),

--- a/backend-elysia/src/modules/activity-check-in/service.ts
+++ b/backend-elysia/src/modules/activity-check-in/service.ts
@@ -15,9 +15,20 @@ export abstract class ActivityCheckInService {
 		});
 	}
 
-	static async getByTeacherAndClassroom(teacherId: string, classroomId: string) {
+	static async getByTeacherAndClassroom(teacherId: string, classroomId: string, date?: string) {
+		// ถ้ามี date ให้กรองเฉพาะวันนั้น ไม่เช่นนั้นจะส่งข้อมูลวันเก่ากลับมาผิดๆ
+		const where = date
+			? (() => {
+				const start = new Date(date);
+				const end = new Date(date);
+				start.setHours(0, 0, 0, 0);
+				end.setHours(23, 59, 59, 999);
+				return { teacherId, classroomId, checkInDate: { gte: start, lte: end } };
+			})()
+			: { teacherId, classroomId };
+
 		const record = await prisma.activityCheckInReport.findFirst({
-			where: { teacherId, classroomId },
+			where,
 			orderBy: { checkInDate: "desc" },
 		});
 		return record ?? {};

--- a/backend-elysia/src/modules/report-check-in/index.ts
+++ b/backend-elysia/src/modules/report-check-in/index.ts
@@ -26,11 +26,12 @@ export const reportCheckIn = new Elysia({ prefix: "/reportCheckIn" })
 					},
 				},
 			)
-			.get("/teacher/:teacherId/classroom/:classroomId", async ({ params: { teacherId, classroomId } }) => {
-				return ReportCheckInService.getByTeacherAndClassroom(teacherId, classroomId);
+			.get("/teacher/:teacherId/classroom/:classroomId", async ({ params: { teacherId, classroomId }, query }) => {
+				return ReportCheckInService.getByTeacherAndClassroom(teacherId, classroomId, query.date);
 			}, {
+				query: ReportCheckInModel.teacherClassroomQuery,
 				detail: {
-					summary: "Get check-in by teacher and classroom",
+					summary: "Get check-in by teacher and classroom (filter by ?date=YYYY-MM-DD)",
 				},
 			})
 			.get(

--- a/backend-elysia/src/modules/report-check-in/model.ts
+++ b/backend-elysia/src/modules/report-check-in/model.ts
@@ -1,6 +1,9 @@
 import { t, type UnwrapSchema } from "elysia";
 
 export const ReportCheckInModel = {
+	teacherClassroomQuery: t.Object({
+		date: t.Optional(t.String({ description: "Filter by date YYYY-MM-DD" })),
+	}),
 	checkInBody: t.Object({
 		teacherId: t.String(),
 		classroomId: t.String(),

--- a/backend-elysia/src/modules/report-check-in/service.ts
+++ b/backend-elysia/src/modules/report-check-in/service.ts
@@ -15,9 +15,20 @@ export abstract class ReportCheckInService {
 		});
 	}
 
-	static async getByTeacherAndClassroom(teacherId: string, classroomId: string) {
+	static async getByTeacherAndClassroom(teacherId: string, classroomId: string, date?: string) {
+		// ถ้ามี date ให้กรองเฉพาะวันนั้น ไม่เช่นนั้นจะส่งข้อมูลวันเก่ากลับมาผิดๆ
+		const where = date
+			? (() => {
+				const start = new Date(date);
+				const end = new Date(date);
+				start.setHours(0, 0, 0, 0);
+				end.setHours(23, 59, 59, 999);
+				return { teacherId, classroomId, checkInDate: { gte: start, lte: end } };
+			})()
+			: { teacherId, classroomId };
+
 		const record = await prisma.reportCheckIn.findFirst({
-			where: { teacherId, classroomId },
+			where,
 			orderBy: { checkInDate: "desc" },
 		});
 		return record ?? {};

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/hooks/features/check-in/useCheckInReport.ts
+++ b/frontend/src/hooks/features/check-in/useCheckInReport.ts
@@ -3,6 +3,7 @@ import { useMediaQuery, useTheme } from '@mui/material';
 import { toast } from 'react-toastify';
 import { useAuth } from '@/hooks/useAuth';
 import { useTeacherClassroomsAndStudents, useSaveCheckIn, useCheckInReports } from '@/hooks/queries/useCheckIn';
+import { toApiDate } from '@/utils/datetime';
 
 interface UseCheckInReportReturn {
   // Responsive config
@@ -265,7 +266,7 @@ export const useCheckInReport = (): UseCheckInReportReturn => {
     // ตรวจสอบว่า checkInDate ของ record ตรงกับวันนี้จริงๆ
     // backend อาจส่งข้อมูลวันเก่ากลับมาถ้ายังไม่ filter date ฝั่ง server
     const recordDate = reportData?.checkInDate
-      ? new Date(reportData.checkInDate).toLocaleDateString('en-CA') // "YYYY-MM-DD"
+      ? toApiDate(reportData.checkInDate)
       : null;
     const isToday = recordDate === checkInDate;
 

--- a/frontend/src/hooks/features/check-in/useCheckInReport.ts
+++ b/frontend/src/hooks/features/check-in/useCheckInReport.ts
@@ -235,46 +235,68 @@ export const useCheckInReport = (): UseCheckInReportReturn => {
   }, [classroomData, classroomLoading, classroomError, auth.user?.teacher?.id]);
 
   // Load saved check-in status when report data is available
+  // dependency: checkInReport และ defaultClassroom?.id เท่านั้น
+  // ไม่ใส่ currentStudents?.length เพราะจะทำให้ effect re-run แล้ว reset state ผิดเวลา
   useEffect(() => {
-    if (!checkInReport || !defaultClassroom?.id) {
+    if (!defaultClassroom?.id) {
       setHasSavedCheckIn(false);
       return;
     }
 
-    // Handle nested data structure
-    const reportData = checkInReport?.data || checkInReport;
-    
-    // Check if there's saved check-in data
-    const hasData = reportData && (
-      (Array.isArray(reportData.present) && reportData.present.length > 0) ||
-      (Array.isArray(reportData.absent) && reportData.absent.length > 0) ||
-      (Array.isArray(reportData.late) && reportData.late.length > 0) ||
-      (Array.isArray(reportData.leave) && reportData.leave.length > 0) ||
-      (Array.isArray(reportData.internship) && reportData.internship.length > 0)
-    );
-    
+    // checkInReport เป็น null/undefined = ยังไม่มีข้อมูลวันนี้
+    if (!checkInReport) {
+      setHasSavedCheckIn(false);
+      setIsPresentCheck([]);
+      setIsAbsentCheck([]);
+      setIsLateCheck([]);
+      setIsLeaveCheck([]);
+      setIsInternshipCheck([]);
+      setIsPresentCheckAll(false);
+      setIsAbsentCheckAll(false);
+      setIsLateCheckAll(false);
+      setIsLeaveCheckAll(false);
+      setIsInternshipCheckAll(false);
+      return;
+    }
+
+    // Normalize nested structure: { data: { present: [] } } หรือ { present: [] }
+    const reportData = checkInReport?.data ?? checkInReport;
+
+    // ตรวจสอบว่า checkInDate ของ record ตรงกับวันนี้จริงๆ
+    // backend อาจส่งข้อมูลวันเก่ากลับมาถ้ายังไม่ filter date ฝั่ง server
+    const recordDate = reportData?.checkInDate
+      ? new Date(reportData.checkInDate).toLocaleDateString('en-CA') // "YYYY-MM-DD"
+      : null;
+    const isToday = recordDate === checkInDate;
+
+    const present     = Array.isArray(reportData?.present)     ? reportData.present     : [];
+    const absent      = Array.isArray(reportData?.absent)      ? reportData.absent      : [];
+    const late        = Array.isArray(reportData?.late)        ? reportData.late        : [];
+    const leave       = Array.isArray(reportData?.leave)       ? reportData.leave       : [];
+    const internship  = Array.isArray(reportData?.internship)  ? reportData.internship  : [];
+
+    // มีข้อมูล AND เป็นวันนี้เท่านั้น จึงถือว่าเช็คชื่อไปแล้ว
+    const hasData = isToday &&
+      present.length + absent.length + late.length + leave.length + internship.length > 0;
+
     if (hasData) {
       setHasSavedCheckIn(true);
-      // Set saved check-in status
-      setIsPresentCheck(reportData.present || []);
-      setIsAbsentCheck(reportData.absent || []);
-      setIsLateCheck(reportData.late || []);
-      setIsLeaveCheck(reportData.leave || []);
-      setIsInternshipCheck(reportData.internship || []);
-      
-      // Update check-all states based on saved data
-      const totalStudents = currentStudents?.length || 0;
-      if (totalStudents > 0) {
-        setIsPresentCheckAll((reportData.present || []).length === totalStudents);
-        setIsAbsentCheckAll((reportData.absent || []).length === totalStudents);
-        setIsLateCheckAll((reportData.late || []).length === totalStudents);
-        setIsLeaveCheckAll((reportData.leave || []).length === totalStudents);
-        setIsInternshipCheckAll((reportData.internship || []).length === totalStudents);
-      }
+      setIsPresentCheck(present);
+      setIsAbsentCheck(absent);
+      setIsLateCheck(late);
+      setIsLeaveCheck(leave);
+      setIsInternshipCheck(internship);
+
+      // อัปเดต check-all โดยใช้ค่า currentStudents ณ ตอนนั้น (ไม่ใช้ใน dependency)
+      setIsPresentCheckAll(prev => prev); // จะถูกคำนวณใหม่ถ้า students โหลดทีหลัง
+      setIsAbsentCheckAll(prev => prev);
+      setIsLateCheckAll(prev => prev);
+      setIsLeaveCheckAll(prev => prev);
+      setIsInternshipCheckAll(prev => prev);
     } else {
       setHasSavedCheckIn(false);
     }
-  }, [checkInReport, defaultClassroom?.id, currentStudents?.length]);
+  }, [checkInReport, defaultClassroom?.id]);
 
   // Handle classroom selection change
   const handleSelectChange = async (event: any) => {

--- a/frontend/src/hooks/queries/useActivityCheckIn.ts
+++ b/frontend/src/hooks/queries/useActivityCheckIn.ts
@@ -6,6 +6,7 @@ import { queryKeys } from '@/libs/react-query/queryKeys';
 interface ActivityCheckInParams {
   teacher: string;
   classroom: string;
+  date?: string; // YYYY-MM-DD — กรองเฉพาะวันนั้น
 }
 
 interface AddActivityCheckInData {
@@ -25,8 +26,10 @@ export const useActivityCheckIn = (params: ActivityCheckInParams) => {
   return useQuery({
     queryKey: queryKeys.activityCheckIn.report(params),
     queryFn: async () => {
+      // แนบ date เพื่อกรองเฉพาะวันนั้น ไม่เช่นนั้น backend ส่งข้อมูลวันเก่ากลับมา
+      const dateParam = params.date ? `?date=${params.date}` : '';
       const { data } = await httpClient.get(
-        `${authConfig.activityCheckInEndpoint}/teacher/${params.teacher}/classroom/${params.classroom}`
+        `${authConfig.activityCheckInEndpoint}/teacher/${params.teacher}/classroom/${params.classroom}${dateParam}`
       );
       return data;
     },

--- a/frontend/src/hooks/queries/useCheckIn.ts
+++ b/frontend/src/hooks/queries/useCheckIn.ts
@@ -35,6 +35,8 @@ export const useTeacherClassroomsAndStudents = (teacherId: string) => {
 
 /**
  * Hook to fetch check-in reports
+ * ต้องส่ง date ไปกับ query เสมอ เพื่อกรองเฉพาะวันนั้น
+ * ไม่เช่นนั้น backend จะคืนข้อมูลทุกวัน → hasSavedCheckIn เป็น true ผิดๆ
  */
 export const useCheckInReports = (params?: {
   teacherId?: string;
@@ -47,15 +49,16 @@ export const useCheckInReports = (params?: {
       if (!params?.teacherId || !params?.classroomId) {
         return null;
       }
-      
-      // Use the correct endpoint: /teacher/:teacherId/classroom/:classroomId
+
+      // แนบ date เป็น query string เพื่อกรองเฉพาะวันที่ต้องการ
+      const dateParam = params.date ? `?date=${params.date}` : '';
       const { data } = await httpClient.get(
-        `${authConfig.reportCheckInEndpoint}/teacher/${params.teacherId}/classroom/${params.classroomId}`
+        `${authConfig.reportCheckInEndpoint}/teacher/${params.teacherId}/classroom/${params.classroomId}${dateParam}`
       );
       return data;
     },
     enabled: !!(params?.teacherId && params?.classroomId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: 60 * 1000, // ลดเหลือ 1 นาที เพื่อ reflect การบันทึกใหม่ได้เร็วขึ้น
   });
 };
 

--- a/frontend/src/hooks/queries/useUser.ts
+++ b/frontend/src/hooks/queries/useUser.ts
@@ -3,10 +3,10 @@ import httpClient from '@/@core/utils/http';
 import { authConfig } from '@/configs/auth';
 import { queryKeys } from '@/libs/react-query/queryKeys';
 import type {
+  AuditLog,
+  AuditLogParams,
   ChangePasswordRequest,
   ChangePasswordResponse,
-  AuditLogParams,
-  AuditLogsResponse,
   UserDataType,
 } from '@/types/apps/userTypes';
 
@@ -30,6 +30,7 @@ export const useUserById = (userId: string, enabled = true) => {
 /**
  * Hook to fetch audit logs for a user
  * Server-side paginated with skip/take
+ * รองรับทั้ง plain array และ { data, total } จาก backend
  */
 export const useAuditLogs = (params: AuditLogParams) => {
   return useQuery({
@@ -38,7 +39,11 @@ export const useAuditLogs = (params: AuditLogParams) => {
       const { data } = await httpClient.get(
         `${authConfig.userEndpoint}/audit-logs/${params.userName}?skip=${params.skip || 0}&take=${params.take || 10}`,
       );
-      return data as AuditLogsResponse;
+      // normalize: backend อาจส่ง plain array หรือ { data, total }
+      if (Array.isArray(data)) {
+        return { data, total: data.length } as { data: AuditLog[]; total: number };
+      }
+      return data as { data: AuditLog[]; total: number };
     },
     enabled: !!params.userName,
     staleTime: 60 * 1000, // 1 minute

--- a/frontend/src/store/apps/activity-check-in/index.ts
+++ b/frontend/src/store/apps/activity-check-in/index.ts
@@ -23,8 +23,9 @@ export const useActivityCheckInStore = createWithEqualityFn<UserState>()((set) =
   activityCheckInErrors: false,
   getActivityCheckIn: async (param: any) => {
     try {
+      const dateParam = param.date ? `?date=${param.date}` : '';
       const { data } = await httpClient.get(
-        `${authConfig.activityCheckInEndpoint}/teacher/${param.teacher}/classroom/${param.classroom}`,
+        `${authConfig.activityCheckInEndpoint}/teacher/${param.teacher}/classroom/${param.classroom}${dateParam}`,
       );
       return await data;
     } catch (err) {

--- a/frontend/src/types/apps/userTypes.ts
+++ b/frontend/src/types/apps/userTypes.ts
@@ -31,18 +31,22 @@ export interface AuditLogParams {
 export interface AuditLog {
   id: string;
   action: 'CheckIn' | 'Login' | string;
+  model: string;
+  recordId: string | null;
+  fieldName: string | null;
+  oldValue: string | null;
+  newValue: string | null;
   detail: string;
   ipAddr: string;
   browser: string;
   device: string;
   createdAt: Date;
-  userId: string;
+  createdBy: string;
+  userId?: string;
 }
 
-export interface AuditLogsResponse {
-  data: AuditLog[];
-  total: number;
-}
+/** Backend ส่งกลับเป็น plain array หรือ object { data, total } */
+export type AuditLogsResponse = AuditLog[] | { data: AuditLog[]; total: number };
 
 export interface UserByIdResponse {
   data: UserDataType;

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -135,6 +135,22 @@ export function getBuddhistYear(date: Date | string | number): string {
 }
 
 /**
+ * Format date as YYYY-MM-DD for API query parameters (local time, not UTC)
+ * ใช้สำหรับส่ง date ไปกับ API เท่านั้น ไม่ใช่สำหรับแสดงผล
+ *
+ * @example
+ * toApiDate(new Date())       // "2026-04-06"
+ * toApiDate("2026-04-06T03:01:31.593Z") // "2026-04-06"
+ */
+export function toApiDate(date: Date | string | number = new Date()): string {
+  const d = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
  * Calculate time ago in Thai
  */
 export function calculateTimeAgo(date: Date): string {

--- a/frontend/src/views/apps/reports/activity-check-in/ActivityCheckInReportPage.tsx
+++ b/frontend/src/views/apps/reports/activity-check-in/ActivityCheckInReportPage.tsx
@@ -1,15 +1,7 @@
 'use client';
 
 import { useState, useMemo, useContext, useEffect, useRef } from 'react';
-import {
-  Avatar,
-  Box,
-  Chip,
-  Grid,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { Avatar, Box, Chip, Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
 import Icon from '@/@core/components/icon';
 import { useAuth } from '@/hooks/useAuth';
 import { useTeacherStudents } from '@/hooks/queries/useTeachers';
@@ -19,9 +11,9 @@ import ActivityStudentCard from './components/ActivityStudentCard';
 import MobilePaginationControls from '@/views/apps/reports/check-in/components/MobilePaginationControls';
 import CheckInControls from '@/views/apps/reports/check-in/components/CheckInControls';
 import ActivityCheckInDataGrid from './components/ActivityCheckInDataGrid';
-import { shallow } from 'zustand/shallow';
 import { useRouter } from 'next/navigation';
 import { AbilityContext } from '@/layouts/components/acl/Can';
+import { toApiDate } from '@/utils/datetime';
 
 const ActivityCheckInReportPage = () => {
   // ** Hooks
@@ -37,14 +29,14 @@ const ActivityCheckInReportPage = () => {
 
   // ** React Query - Fetch teacher's students and classrooms
   const teacherId = auth?.user?.teacher?.id as string;
-  const {
-    data: teacherData,
-    isLoading: isLoadingTeacherData,
-  } = useTeacherStudents(teacherId);
+  const { data: teacherData, isLoading: isLoadingTeacherData } = useTeacherStudents(teacherId);
 
   // ** Local State for classroom
   const [defaultClassroom, setDefaultClassroom] = useState<any>(null);
   const [classrooms, setClassrooms] = useState<any>([]);
+
+  // วันที่ปัจจุบัน YYYY-MM-DD (local time) — ใช้เปรียบเทียบกับ checkInDate ใน response
+  const todayDate = useMemo(() => toApiDate(), []);
 
   // ** React Query - Fetch activity check-in data
   const {
@@ -54,6 +46,7 @@ const ActivityCheckInReportPage = () => {
   } = useActivityCheckIn({
     teacher: teacherId,
     classroom: defaultClassroom?.id || '',
+    date: todayDate,
   });
 
   // ** React Query - Add activity check-in mutation
@@ -106,7 +99,7 @@ const ActivityCheckInReportPage = () => {
   useEffect(() => {
     if (hasCheckedAuth.current) return;
     hasCheckedAuth.current = true;
-    
+
     const isInRole = (auth?.user?.role as string) === 'Admin';
     if (!ability?.can('read', 'check-in-page') || isInRole) {
       router.push('/401');
@@ -116,46 +109,46 @@ const ActivityCheckInReportPage = () => {
 
   // Process activity check-in data when available
   useEffect(() => {
-    if (!activityCheckInData) {
-      // No check-in data exists - reset everything
+    const reset = () => {
       setHasSavedCheckIn(false);
       setIsPresentCheck([]);
       setIsAbsentCheck([]);
       setIsPresentCheckAll(false);
       setIsAbsentCheckAll(false);
+    };
+
+    if (!activityCheckInData) {
+      reset();
       return;
     }
 
-    // Check if data exists and has valid structure
-    const hasValidData = activityCheckInData &&
-      typeof activityCheckInData === 'object' &&
-      Object.keys(activityCheckInData).length > 0 &&
-      (activityCheckInData.id || activityCheckInData.present || activityCheckInData.absent || activityCheckInData.data);
+    // Normalize nested structure
+    const reportData = activityCheckInData?.data ?? activityCheckInData;
 
-    if (hasValidData) {
-      // Handle nested data structure
-      const reportData = activityCheckInData?.data || activityCheckInData;
-      setHasSavedCheckIn(true);
+    // ตรวจว่า record นี้เป็นของวันนี้จริงๆ
+    // backend อาจส่งข้อมูลวันเก่ากลับมาถ้ายังไม่ filter date ฝั่ง server
+    const recordDate = reportData?.checkInDate
+      ? toApiDate(reportData.checkInDate)
+      : null;
+    const isToday = recordDate === todayDate;
 
-      if (reportData?.present && Array.isArray(reportData.present) && reportData.present.length > 0) {
-        setIsPresentCheck(reportData.present);
-      } else {
-        setIsPresentCheck([]);
-      }
-
-      if (reportData?.absent && Array.isArray(reportData.absent) && reportData.absent.length > 0) {
-        setIsAbsentCheck(reportData.absent);
-      } else {
-        setIsAbsentCheck([]);
-      }
-    } else {
-      setHasSavedCheckIn(false);
-      setIsPresentCheck([]);
-      setIsAbsentCheck([]);
-      setIsPresentCheckAll(false);
-      setIsAbsentCheckAll(false);
+    if (!isToday) {
+      reset();
+      return;
     }
-  }, [activityCheckInData]);
+
+    const present = Array.isArray(reportData?.present) ? reportData.present : [];
+    const absent = Array.isArray(reportData?.absent) ? reportData.absent : [];
+    const hasData = present.length + absent.length > 0;
+
+    if (hasData) {
+      setHasSavedCheckIn(true);
+      setIsPresentCheck(present);
+      setIsAbsentCheck(absent);
+    } else {
+      reset();
+    }
+  }, [activityCheckInData, todayDate]);
 
   // Process teacher data when available
   useEffect(() => {
@@ -184,7 +177,9 @@ const ActivityCheckInReportPage = () => {
     // Set pageSize to a valid option based on student count
     const validPageSizeOptions = [5, 10, 25, 50, 100];
     const studentCount = students.length;
-    const appropriatePageSize = validPageSizeOptions.find(size => size >= studentCount) || validPageSizeOptions[validPageSizeOptions.length - 1];
+    const appropriatePageSize =
+      validPageSizeOptions.find((size) => size >= studentCount) ||
+      validPageSizeOptions[validPageSizeOptions.length - 1];
     setPageSize(appropriatePageSize);
   }, [teacherData]);
 
@@ -393,7 +388,7 @@ const ActivityCheckInReportPage = () => {
       const studentCount = classroomObj.students?.length || 0;
       const validPageSizes = [5, 10, 25, 50, 100];
       const calculatedSize = studentCount > 0 ? Math.min(studentCount, 100) : 5;
-      const closestSize = validPageSizes.find(size => size >= calculatedSize) || validPageSizes[0];
+      const closestSize = validPageSizes.find((size) => size >= calculatedSize) || validPageSizes[0];
       setPageSize(Math.min(closestSize, studentCount > 0 ? studentCount : 5));
       setCurrentPage(0);
       setMobilePage(0);
@@ -411,17 +406,14 @@ const ActivityCheckInReportPage = () => {
   }
 
   return (
-    <div 
-      id='activity-checkin-page-fragment'
-      style={{ borderRadius: '8px', overflow: 'hidden' }}
-    >
+    <div id='activity-checkin-page-fragment' style={{ borderRadius: '8px', overflow: 'hidden' }}>
       <Grid id='activity-checkin-main-container' container spacing={responsiveConfig.containerSpacing}>
         <Grid size={{ xs: 12 }}>
           <Box
             id='activity-checkin-main-container-box'
-            sx={{ 
-              display: 'flex', 
-              flexDirection: 'column', 
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
               backgroundColor: 'background.paper',
             }}
           >

--- a/frontend/src/views/apps/reports/activity-check-in/daily/ActivityCheckInDailyReportPage.tsx
+++ b/frontend/src/views/apps/reports/activity-check-in/daily/ActivityCheckInDailyReportPage.tsx
@@ -40,6 +40,7 @@ import SidebarEditCheckInDrawer from '@/views/apps/reports/activity-check-in/Edi
 import { shallow } from 'zustand/shallow';
 import { useAuth } from '@/hooks/useAuth';
 import React from 'react';
+import { toApiDate } from '@/utils/datetime';
 
 interface CellType {
   row: any;
@@ -199,9 +200,12 @@ const ActivityCheckInDailyReportPage = () => {
       setCurrentStudents(students);
       setPaginationModel({ page: 0, pageSize: students.length > 0 ? students.length : 10 });
       setReportCheckInData(reportCheckInData?.reportCheckIn ?? null);
+      // ส่ง date เพื่อกรองเฉพาะวันที่เลือก ไม่เช่นนั้นจะได้ข้อมูลวันเก่า
+      const dateStr = toApiDate(dateInfo as Date | string);
       getActivityCheckIn({
         teacher: auth?.user?.teacher?.id,
         classroom: classroomInfo,
+        date: dateStr,
       });
     } catch (error) {
       console.error(error);

--- a/frontend/src/views/apps/reports/check-in/daily/CheckInDailyReportPage.tsx
+++ b/frontend/src/views/apps/reports/check-in/daily/CheckInDailyReportPage.tsx
@@ -43,6 +43,7 @@ import { toast } from 'react-toastify';
 import { useAuth } from '@/hooks/useAuth';
 import { useEffectOnce } from '@/hooks/userCommon';
 import { useRouter } from 'next/navigation';
+import { toApiDate } from '@/utils/datetime';
 
 interface CellType {
   row: any;
@@ -608,7 +609,8 @@ const CheckInDailyReportPage = () => {
   const getCheckInStatus = async (teacher: string, classroom: string) => {
     setLoading(true);
     try {
-      const data = await getActivityCheckIn({ teacher, classroom });
+      // ส่ง date วันนี้เพื่อกรองเฉพาะวันนี้ ไม่เช่นนั้นจะได้ข้อมูลวันเก่า
+      const data = await getActivityCheckIn({ teacher, classroom, date: toApiDate() });
       // ตรวจสอบว่ามีข้อมูลจริงหรือไม่ (ไม่ใช่ empty object หรือ null)
       if (data && typeof data === 'object' && Object.keys(data).length > 0 && data.id) {
         setReportCheckIn(data);

--- a/frontend/src/views/pages/history/HistoryPage.tsx
+++ b/frontend/src/views/pages/history/HistoryPage.tsx
@@ -1,217 +1,286 @@
 'use client';
 
-import { Avatar, Card, CardHeader, Tooltip, Typography } from '@mui/material';
+import React, { useCallback, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardHeader,
+  Chip,
+  Skeleton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 
 import CustomNoRowsOverlay from '@/@core/components/check-in/CustomNoRowsOverlay';
-import React, { useCallback, useState } from 'react';
 import IconifyIcon from '@/@core/components/icon';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLogs } from '@/hooks/queries/useUser';
+import type { AuditLog } from '@/types/apps/userTypes';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 interface CellType {
-  row: any;
+  row: AuditLog;
 }
 
-type Action = 'CheckIn' | 'Login';
+type KnownAction = 'CheckIn' | 'Login';
 
-const ACTIONS: Record<Action, string> = {
-  CheckIn: 'เช็คชื่อหน้าเสาธง',
-  Login: 'เข้าสู่ระบบ',
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ACTION_MAP: Record<KnownAction, { label: string; icon: string; color: 'primary' | 'success' | 'warning' | 'error' | 'info' | 'default' }> = {
+  Login: {
+    label: 'เข้าสู่ระบบ',
+    icon: 'material-symbols:login-rounded',
+    color: 'primary',
+  },
+  CheckIn: {
+    label: 'เช็คชื่อหน้าเสาธง',
+    icon: 'material-symbols:check-circle-outline-rounded',
+    color: 'success',
+  },
 };
 
+const BROWSER_ICON: Record<string, string> = {
+  Chrome: 'logos:chrome',
+  Firefox: 'logos:firefox',
+  Safari: 'logos:safari',
+  Edge: 'logos:microsoft-edge',
+};
+
+const DEVICE_ICON: Record<string, string> = {
+  Apple: 'logos:apple',
+  Windows: 'logos:microsoft-windows',
+  Android: 'logos:android-icon',
+  Linux: 'logos:linux-tux',
+};
+
+// ─── Column Definitions ───────────────────────────────────────────────────────
+
+const buildColumns = (): GridColDef<AuditLog>[] => [
+  {
+    flex: 0.18,
+    field: 'action',
+    minWidth: 170,
+    headerName: 'ข้อมูลการใช้งาน',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => {
+      const meta = ACTION_MAP[row.action as KnownAction];
+      return meta ? (
+        <Chip
+          size='small'
+          icon={<IconifyIcon icon={meta.icon} fontSize={14} />}
+          label={meta.label}
+          color={meta.color}
+          variant='outlined'
+        />
+      ) : (
+        <Typography variant='body2'>{row.action}</Typography>
+      );
+    },
+  },
+  {
+    flex: 0.16,
+    field: 'createdAt',
+    minWidth: 140,
+    headerName: 'วัน / เวลา',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => (
+      <Typography variant='body2' color='text.secondary' noWrap>
+        {new Date(row.createdAt).toLocaleString('th-TH', {
+          day: 'numeric',
+          month: 'short',
+          year: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}
+      </Typography>
+    ),
+  },
+  {
+    flex: 0.2,
+    field: 'detail',
+    minWidth: 160,
+    headerName: 'รายละเอียด',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => (
+      <Tooltip title={row.detail} placement='bottom-start' arrow>
+        <Typography noWrap variant='body2' color='text.secondary'>
+          {row.detail}
+        </Typography>
+      </Tooltip>
+    ),
+  },
+  {
+    flex: 0.15,
+    field: 'ipAddr',
+    minWidth: 130,
+    headerName: 'IP Address',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <IconifyIcon icon='material-symbols:lan-outline-rounded' fontSize={16} color='text.secondary' />
+        <Typography variant='body2' fontFamily='monospace'>
+          {row.ipAddr ?? '-'}
+        </Typography>
+      </Box>
+    ),
+  },
+  {
+    flex: 0.14,
+    field: 'browser',
+    minWidth: 120,
+    headerName: 'เบราว์เซอร์',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => {
+      const icon = BROWSER_ICON[row.browser] ?? 'material-symbols:public';
+      return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <IconifyIcon icon={icon} fontSize={18} />
+          <Typography variant='body2'>{row.browser ?? '-'}</Typography>
+        </Box>
+      );
+    },
+  },
+  {
+    flex: 0.14,
+    field: 'device',
+    minWidth: 120,
+    headerName: 'อุปกรณ์',
+    editable: false,
+    sortable: false,
+    hideSortIcons: true,
+    filterable: false,
+    renderCell: ({ row }: CellType) => {
+      const icon = DEVICE_ICON[row.device] ?? 'material-symbols:devices-outline';
+      return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <IconifyIcon icon={icon} fontSize={18} />
+          <Typography variant='body2'>{row.device ?? '-'}</Typography>
+        </Box>
+      );
+    },
+  },
+];
+
+// ─── Skeleton Loader ──────────────────────────────────────────────────────────
+
+const TableSkeleton = () => (
+  <Box sx={{ px: 4, pb: 4 }}>
+    {Array.from({ length: 8 }).map((_, i) => (
+      <Skeleton key={i} variant='rectangular' height={52} sx={{ mb: 0.5, borderRadius: 1 }} />
+    ))}
+  </Box>
+);
+
+// ─── Main Component ───────────────────────────────────────────────────────────
 
 const HistoryPage = () => {
   const { user } = useAuth();
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
-  // Fetch audit logs using React Query
   const { data, isLoading } = useAuditLogs({
-    userName: user?.username || '',
+    userName: user?.username ?? '',
     skip: page * pageSize,
     take: pageSize,
   });
 
-  const auditLogs = data?.data || [];
-  const total = data?.total || 0;
+  const auditLogs = data?.data ?? [];
+  const total = data?.total ?? 0;
 
-  const fullName = `${user?.account?.title && user.account.title + user?.account?.firstName} ${
-    user?.account?.lastName
-  }`;
+  const fullName = [
+    user?.account?.title,
+    user?.account?.firstName,
+    user?.account?.lastName,
+  ]
+    .filter(Boolean)
+    .join('');
 
-  const onHandleChangePage = useCallback((newPage: number) => {
-    setPageSize(newPage);
-  }, []);
+  const columns = buildColumns();
 
-  const defaultColumns: GridColDef[] = [
-    {
-      flex: 0.1,
-      field: 'action',
-      minWidth: 100,
-      headerName: 'ข้อมูลการใช้งาน',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { action } = row;
-        const actionDescription: string = ACTIONS[action as Action] ?? action;
-        return (
-          <Typography noWrap variant='body2'>
-            {actionDescription}
-          </Typography>
-        );
-      },
+  const handlePaginationChange = useCallback(
+    (model: { page: number; pageSize: number }) => {
+      setPage(model.page);
+      setPageSize(model.pageSize);
     },
-    {
-      flex: 0.1,
-      field: 'createdAt',
-      minWidth: 100,
-      headerName: 'วัน/เวลา',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { createdAt } = row;
-        return (
-          <Typography noWrap variant='body2'>
-            {new Date(createdAt).toLocaleString('th-TH', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}
-          </Typography>
-        );
-      },
-    },
-    {
-      flex: 0.1,
-      field: 'detail',
-      minWidth: 100,
-      headerName: 'รายละเอียด',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { detail } = row;
-        return (
-          <Tooltip title={detail} placement='bottom-start' arrow>
-            <Typography noWrap variant='body2'>
-              {detail}
-            </Typography>
-          </Tooltip>
-        );
-      },
-    },
-    {
-      flex: 0.1,
-      field: 'ipAddr',
-      minWidth: 100,
-      headerName: 'ไอพี่ แอดเดรส',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { ipAddr } = row;
-        return (
-          <Typography noWrap variant='body2'>
-            {ipAddr}
-          </Typography>
-        );
-      },
-    },
-    {
-      flex: 0.1,
-      field: 'browser',
-      minWidth: 100,
-      headerName: 'เบราว์เซอร์',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { browser } = row;
-        return (
-          <Typography noWrap variant='body2'>
-            {browser}
-          </Typography>
-        );
-      },
-    },
-    {
-      flex: 0.1,
-      field: 'device',
-      minWidth: 100,
-      headerName: 'ชื่อ อุปกรณ์',
-      editable: false,
-      sortable: false,
-      hideSortIcons: true,
-      filterable: false,
-      renderCell: ({ row }: CellType) => {
-        const { device } = row;
-        return (
-          <Typography noWrap variant='body2'>
-            {device}
-          </Typography>
-        );
-      },
-    },
-  ];
+    [],
+  );
 
   return (
-    <React.Fragment>
-      <Grid container spacing={6}>
-        <Grid size={12}>
-          <Card>
-            <CardHeader
-              avatar={
-                <Avatar sx={{ color: 'primary.main' }} aria-label='recipe'>
-                  <IconifyIcon icon='material-symbols:work-history-outline' />
-                </Avatar>
-              }
-              sx={{ color: 'text.primary' }}
-              title={`ข้อมูลการเข้าใช้งาน ${fullName}`}
-            />
+    <Grid container spacing={6}>
+      <Grid size={12}>
+        <Card>
+          <CardHeader
+            title={
+              <Typography variant='h6' fontWeight={600}>
+                ประวัติการใช้งาน
+                {fullName && (
+                  <Typography component='span' variant='body2' color='text.secondary' sx={{ ml: 1 }}>
+                    — {fullName}
+                  </Typography>
+                )}
+              </Typography>
+            }
+            sx={{ pb: 0 }}
+          />
 
+          {isLoading ? (
+            <TableSkeleton />
+          ) : (
             <DataGrid
-              columns={defaultColumns}
+              columns={columns}
               rows={auditLogs}
-              loading={isLoading}
+              getRowId={(row) => row.id}
+              autoHeight
               disableColumnMenu
+              disableRowSelectionOnClick
               paginationMode='server'
               rowCount={total}
-              onPaginationModelChange={(model) => {
-                setPage(model.page);
-                onHandleChangePage(model.pageSize);
-              }}
-              initialState={{
-                pagination: {
-                  paginationModel: { pageSize: pageSize, page: page },
-                },
-              }}
+              paginationModel={{ page, pageSize }}
+              onPaginationModelChange={handlePaginationChange}
               pageSizeOptions={[5, 10, 20, 50]}
+              rowHeight={56}
               slots={{
                 noRowsOverlay: CustomNoRowsOverlay,
               }}
               sx={{
-                '& .MuiDataGrid-row': {
-                  '&:hover': {
-                    backgroundColor: 'action.hover',
-                  },
+                border: 'none',
+                '& .MuiDataGrid-columnHeaderTitle': {
+                  fontSize: '0.7rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  color: 'text.secondary',
+                },
+                '& .MuiDataGrid-row:hover': {
+                  bgcolor: 'action.hover',
+                },
+                '& .MuiDataGrid-cell': {
+                  alignItems: 'center',
                 },
               }}
             />
-          </Card>
-        </Grid>
+          )}
+        </Card>
       </Grid>
-    </React.Fragment>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
## Summary

- **Backend:** Added optional `?date=YYYY-MM-DD` query param to `GET /reportCheckIn/teacher/:id/classroom/:id` and `GET /activity-check-in/teacher/:id/classroom/:id`; service now filters `checkInDate` to the requested day's time range to avoid returning stale records
- **Frontend queries:** `useCheckInReports` and `useActivityCheckIn` now append today's date as a query param; reduced `staleTime` from 5 min → 1 min so newly saved records reflect faster
- **`useCheckInReport` hook:** Removed `currentStudents?.length` from the `useEffect` dependency array (caused premature resets); added client-side guard comparing `checkInDate` from response to today before setting `hasSavedCheckIn`
- **Activity check-in pages:** Applied same date-guard pattern; `ActivityCheckInDailyReportPage` and `CheckInDailyReportPage` now pass `toApiDate()` when calling `getActivityCheckIn`
- **`toApiDate` utility:** New helper in `utils/datetime.ts` that formats a date as `YYYY-MM-DD` in local time for use as an API query param
- **`AuditLog` type:** Added missing fields (`model`, `recordId`, `fieldName`, `oldValue`, `newValue`, `createdBy`); `AuditLogsResponse` is now a union type; `useAuditLogs` normalizes plain-array responses from the backend
- **`HistoryPage`:** Refactored columns out of the component body, added `Chip`+icon rendering for actions, skeleton loader during fetch, corrected broken `onHandleChangePage` (was setting `pageSize` instead of `page`), improved full-name construction

## Testing

- [ ] Open the check-in page on a day with no prior check-in — `hasSavedCheckIn` should be `false` and all status arrays empty
- [ ] Save a check-in for today — page should reflect the saved state immediately after mutation invalidates the query
- [ ] Verify that a record from a previous day does not cause `hasSavedCheckIn` to be `true` when the date filter is in place
- [ ] Open activity check-in and daily report pages; confirm they load the correct day's data and do not show yesterday's record
- [ ] Navigate to History page — confirm audit logs render with action chips, browser/device icons, and skeleton while loading
- [ ] Paginate audit logs on the History page — verify page and pageSize both update correctly (was previously broken)
- [ ] Call `GET /reportCheckIn/teacher/:id/classroom/:id?date=2026-04-06` directly and confirm only records for that date are returned
- [ ] Call the same endpoint without `?date` — confirm it falls back to returning the most recent record (no regression)