### PR TITLE
feat: classroom student management — promotion, graduation, and view redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,45 @@
 # Changelog
 
-## [Unreleased]
+## [Unreleased] — feature/classroom-student-management
 
-### Features
-- **Student promotion**: add `promote-preview` and `promote` endpoints for moving students between classrooms; add `usePromotePreview` / `usePromoteStudents` React Query hooks
-- **Student creation**: add duplicate `studentId` / username conflict detection with `ConflictError`; wrap full create flow in Prisma transaction
-- **Teacher import**: validate role before upsert (reject non-Teacher username conflicts); add transaction-based account upsert for existing users
+### Added
 
-### Bug Fixes
+- **Student view page** — full redesign with real API data; 2-column layout, tabbed panels (overview / goodness / badness), back button, trophy score display, and tab count badges
+- **Student detail card** — personal info and academic info sections with skeleton loading
+- **Classroom promotion dialog** — promote all students from one classroom to another with conflict detection and preview
+- **Student individual promotion dialog** — promote a single student to a target classroom
+- **Student graduation dialogs** — per-student and bulk classroom graduation flows with graduation year/date inputs
+- **Shared dialog components** — `ConfirmDialog`, `GenericDeleteDialog`, `GenericGraduationDialog` extracted to `@core/components/dialogs` for reuse
+- **Delete dialog wrappers** — `ClassroomDeleteDialog`, `DepartmentDeleteDialog`, `ProgramDeleteDialog`, `StudentDeleteDialog`, `TeacherDeleteDialog` using shared generic components
+- `useStudentClassroomTeachers` hook — fetches teachers for a student's classroom via dedicated backend endpoint
+- `useGraduateClassroom` and `useGraduateStudent` query hooks
+- Backend: `promote-classroom`, `graduate-classroom`, and `promote-preview` student endpoints (Elysia)
+
+### Fixed
+
+- Student list blank after navigating back from student view — query disabled until classroom ID initialised
+- Trophy scores showing 0 — backend field names (`goodnessScore`/`badnessScore`/`goodnessCount`) normalised to component expectations (`goodScore`/`badScore`/`totalTrophy`) in `useStudentTrophyOverview`
+- Hydration error: `<div>` inside `<p>` in `StudentDetailCard` — replaced `Typography` with `Box` in `DetailRow`
+- Student edit cancel button (`#student-edit-cancel-btn`) now uses `router.push` with classroom param preserved instead of `router.back()` which caused blank page
+- Student edit save success also navigates to correct list URL preserving classroom param
+- `TimelineGoodness` was only rendering the first record — now maps all records
+- Removed stale `@ts-expect-error` directives in `TimelineGoodness` and `TimelineBadness`
 - Fix student delete endpoint URL (`/profile/:id` → `/:id`)
 - Fix student create endpoint URL (trailing slash)
 - Remove `importTeachersFromXLSX` duplicate from `xlsx.ts` (logic moved to service layer)
 
+### Changed
+
+- Delete dialogs for classroom, department, program, teacher, and student refactored to use shared `GenericDeleteDialog`
+- `ClassroomSettingsPage` — promotion and graduation actions added to classroom row actions
+- `StudentListPage` and `TableHeader` — individual promotion action available per student row; filter/action controls updated
+- **Student promotion**: add `promote-preview` and `promote` endpoints for moving students between classrooms; add `usePromotePreview` / `usePromoteStudents` React Query hooks
+- **Student creation**: add duplicate `studentId` / username conflict detection with `ConflictError`; wrap full create flow in Prisma transaction
+- **Teacher import**: validate role before upsert; add transaction-based account upsert for existing users
+
 ### Code Quality
+
 - Add `<Suspense>` boundary around `StudentListPage` to satisfy `useSearchParams` requirement
 - Add `role="button"` + `onKeyDown` to clickable div in `TimelineGoodness` (a11y)
 - Add `suppressHydrationWarning` to date-formatted `Typography` nodes
 - Use lazy state initializer `() => ThailandAddressValueHelper.empty()` in `StudentAddPage`
-- Destructure `push` / `back` from `useRouter()` in `StudentAddPage` / `StudentEditPage`
-- React Doctor score: 93 → 95

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,26 @@
+# Product
+
+## Register
+
+product
+
+## Users
+Thai vocational college administrators, teachers, and academic staff at NKTC (วิทยาลัยเทคนิค). They work in a desktop/office environment managing classroom rosters, daily attendance, behavior records, home visit logs, and graduation workflows. Primary context: data entry and workflow completion on a desktop monitor during working hours.
+
+## Product Purpose
+NKTC Student Management System — internal operations tool for a Thai vocational college. Centralizes student records, check-in/attendance, behavior assessments, home visit records, and graduation management. Success = staff process daily student workflows quickly without errors or confusion.
+
+## Brand Personality
+Reliable, structured, institutional. Represents an official educational authority — authoritative and trustworthy without being cold, efficient without being spartan.
+
+## Anti-references
+Consumer apps that feel playful or casual. Heavily decorated SaaS dashboard templates that prioritize visual flair over task completion. Generic admin panel frameworks with no identity.
+
+## Design Principles
+1. Clarity over cleverness — data-entry and workflow tasks must be scannable in seconds
+2. Institutional authority — structure and consistency build trust, not decoration
+3. Error prevention first — destructive or irreversible bulk actions need unambiguous visual treatment
+4. Respect the workflow — minimize steps, confirm only when stakes are real
+
+## Accessibility & Inclusion
+Thai-language primary UI. WCAG AA minimum. Legible on standard 1080p office monitors. Reduced motion respected via MUI system.

--- a/backend-elysia/src/modules/students/index.ts
+++ b/backend-elysia/src/modules/students/index.ts
@@ -137,6 +137,21 @@ export const students = new Elysia({ prefix: "/students" })
 					detail: { summary: "Promote all students from one classroom to another" },
 				},
 			)
+			.post(
+				"/graduate-classroom",
+				async ({ body, user, set }) => {
+					if ((user as any)?.roles !== "Admin") {
+						set.status = 403;
+						return { success: false, message: "Forbidden" };
+					}
+					const { classroomId, graduationYear, graduationDate } = body as StudentModel["graduateClassroomBody"];
+					return StudentService.graduateClassroom(classroomId, graduationYear, (user as any).sub, graduationDate);
+				},
+				{
+					body: StudentModel.graduateClassroomBody,
+					detail: { summary: "Graduate all students in a classroom" },
+				},
+			)
 			.get(
 				"/promote-preview",
 				async ({ query, user, set }) => {

--- a/backend-elysia/src/modules/students/model.ts
+++ b/backend-elysia/src/modules/students/model.ts
@@ -7,6 +7,7 @@ export const StudentModel = {
     classroomId: t.Optional(t.Union([t.String(), t.Null()])),
     departmentId: t.Optional(t.Union([t.String(), t.Null()])),
     programId: t.Optional(t.Union([t.String(), t.Null()])),
+    studentStatus: t.Optional(t.Union([t.String(), t.Null()])),
     search: t.Optional(
       t.Object({
         fullName: t.Optional(t.String()),
@@ -50,6 +51,11 @@ export const StudentModel = {
   promoteBody: t.Object({
     sourceClassroomId: t.String(),
     targetClassroomId: t.String(),
+  }),
+  graduateClassroomBody: t.Object({
+    classroomId: t.String(),
+    graduationYear: t.Integer(),
+    graduationDate: t.Optional(t.Union([t.String(), t.Date()])),
   }),
   updateBody: t.Object({
     studentId: t.Optional(t.String()),

--- a/backend-elysia/src/modules/students/service.ts
+++ b/backend-elysia/src/modules/students/service.ts
@@ -96,6 +96,7 @@ export abstract class StudentService {
       take = 1000,
       departmentId,
       programId,
+      studentStatus,
     } = params;
 
     // Support both q (from GET) and search object (from POST)
@@ -136,10 +137,17 @@ export abstract class StudentService {
       }
     }
 
+    const statusCondition = studentStatus
+      ? studentStatus === 'graduated'
+        ? { OR: [{ studentStatus: 'graduated' }, { isGraduation: true }] }
+        : { studentStatus }
+      : {};
+
     const whereCondition = {
       ...(classroomId ? { classroomId } : {}),
       ...(departmentId ? { departmentId } : {}),
       ...(programId ? { programId } : {}),
+      ...statusCondition,
       ...(searchConditions.length > 0 ? { OR: searchConditions } : {}),
     };
 
@@ -472,6 +480,48 @@ export abstract class StudentService {
       promoted: count,
       sourceClassroom: source.name,
       targetClassroom: target.name,
+    };
+  }
+
+  static async graduateClassroom(classroomId: string, graduationYear: number, graduatedBy: string, rawGraduationDate?: string | Date) {
+    const classroom = await prisma.classroom.findUnique({
+      where: { id: classroomId },
+      select: { id: true, name: true },
+    });
+
+    if (!classroom) throw new NotFoundError("ไม่พบห้องเรียน");
+
+    const graduationDate = rawGraduationDate ? new Date(rawGraduationDate as any) : new Date();
+
+    const { count } = await prisma.student.updateMany({
+      where: {
+        classroomId,
+        OR: [{ isGraduation: false }, { isGraduation: null }],
+      },
+      data: {
+        isGraduation: true,
+        graduationYear,
+        graduationDate,
+        studentStatus: "graduated",
+        updatedBy: graduatedBy,
+      },
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        action: "GRADUATE_CLASSROOM",
+        model: "Student",
+        detail: `จบการศึกษานักเรียน ${count} คน จากห้อง "${classroom.name}" ปีการศึกษา ${graduationYear}`,
+        oldValue: classroom.id,
+        newValue: String(graduationYear),
+        createdBy: graduatedBy,
+      },
+    });
+
+    return {
+      graduated: count,
+      classroom: classroom.name,
+      graduationYear,
     };
   }
 

--- a/frontend/src/@core/components/dialogs/ConfirmDialog.tsx
+++ b/frontend/src/@core/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { alpha, Box } from '@mui/material';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Typography,
+} from '@mui/material';
+import { RiDeleteBinLine, RiAlertLine, RiInformationLine, RiCheckLine } from 'react-icons/ri';
+
+export interface ConfirmDialogOptions {
+  title: string;
+  message: ReactNode;
+  severity?: 'error' | 'warning' | 'info' | 'success';
+  icon?: string;
+  confirmText?: string;
+  cancelText?: string;
+  showWarning?: boolean;
+  warningMessage?: string;
+  disabled?: boolean;
+}
+
+interface ConfirmDialogProps {
+  open: boolean;
+  options: ConfirmDialogOptions;
+  onClose: () => void;
+  onConfirm: () => void;
+  isConfirming?: boolean;
+}
+
+const ICON_MAP = {
+  error: RiDeleteBinLine,
+  warning: RiAlertLine,
+  info: RiInformationLine,
+  success: RiCheckLine,
+} as const;
+
+const COLOR_MAP = {
+  error: 'error' as const,
+  warning: 'warning' as const,
+  info: 'info' as const,
+  success: 'success' as const,
+} as const;
+
+const ConfirmDialog = ({ open, options, onClose, onConfirm, isConfirming = false }: ConfirmDialogProps) => {
+  const {
+    title,
+    message,
+    severity = 'error',
+    icon,
+    confirmText = 'ยืนยัน',
+    cancelText = 'ยกเลิก',
+    showWarning = false,
+    warningMessage,
+    disabled = false,
+  } = options;
+
+  const IconComponent = icon || ICON_MAP[severity];
+  const color = COLOR_MAP[severity];
+
+  return (
+    <Dialog
+      open={open}
+      fullWidth
+      maxWidth='xs'
+      onClose={isConfirming ? undefined : onClose}
+      aria-labelledby={`${severity}-confirm-dialog-title`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette[color].main, 0.12),
+            color: `${color}.main`,
+            mb: 3,
+          }}
+        >
+          <IconComponent width={32} height={32} />
+        </Box>
+        <Typography variant='h6' fontWeight={600} textAlign='center' id={`${severity}-confirm-dialog-title`}>
+          {title}
+        </Typography>
+      </Box>
+
+      <DialogContent sx={{ px: 6, pt: 2, pb: showWarning ? 3 : 4, textAlign: 'center' }}>
+        <Typography variant='body2' color='text.secondary' sx={{ lineHeight: 1.8 }}>
+          {message}
+        </Typography>
+        {showWarning && warningMessage && (
+          <Alert severity={severity} sx={{ borderRadius: 2, mt: 2 }}>
+            {warningMessage}
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+        <Button
+          variant='outlined'
+          color='inherit'
+          onClick={onClose}
+          disabled={isConfirming || disabled}
+          fullWidth
+          id={`${severity}-confirm-dialog-cancel`}
+        >
+          {cancelText}
+        </Button>
+        <Button
+          variant='contained'
+          color={severity === 'error' ? 'error' : severity === 'warning' ? 'warning' : 'primary'}
+          onClick={onConfirm}
+          disabled={isConfirming || disabled}
+          fullWidth
+          id={`${severity}-confirm-dialog-confirm`}
+        >
+          {isConfirming ? 'กำลังดำเนินการ...' : confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend/src/@core/components/dialogs/GenericDeleteDialog.tsx
+++ b/frontend/src/@core/components/dialogs/GenericDeleteDialog.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { memo } from 'react';
+import { Typography } from '@mui/material';
+
+import ConfirmDialog, { type ConfirmDialogOptions } from './ConfirmDialog';
+
+interface GenericDeleteDialogProps {
+  open: boolean;
+  title: string;
+  itemName: string;
+  itemIdentifier?: string;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  warningMessage?: string;
+}
+
+const GenericDeleteDialog = memo(
+  ({ open, title, itemName, itemIdentifier, isDeleting, onClose, onConfirm, warningMessage }: GenericDeleteDialogProps) => {
+    const options: ConfirmDialogOptions = {
+      title,
+      message: (
+        <>
+          คุณต้องการลบ{' '}
+          <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+            {itemName}
+          </Typography>
+          {itemIdentifier && (
+            <>
+              {' '}
+              <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+                ({itemIdentifier})
+              </Typography>
+            </>
+          )}
+          {' ใช่หรือไม่?'}
+        </>
+      ),
+      severity: 'error',
+      confirmText: 'ลบ',
+      cancelText: 'ยกเลิก',
+      showWarning: !!warningMessage,
+      warningMessage,
+    };
+
+    return <ConfirmDialog open={open} options={options} onClose={onClose} onConfirm={onConfirm} isConfirming={isDeleting} />;
+  },
+);
+
+GenericDeleteDialog.displayName = 'GenericDeleteDialog';
+
+export default GenericDeleteDialog;

--- a/frontend/src/@core/components/dialogs/GenericGraduationDialog.tsx
+++ b/frontend/src/@core/components/dialogs/GenericGraduationDialog.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { memo, useState } from 'react';
+import { alpha, Box } from '@mui/material';
+import { RiGraduationCapLine } from 'react-icons/ri';
+
+import ThaiDatePicker from '@/@core/components/mui/date-picker-thai';
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Typography,
+} from '@mui/material';
+
+interface GenericGraduationDialogProps {
+  open: boolean;
+  title: string;
+  entityName: string;
+  isGraduating: boolean;
+  onClose: () => void;
+  onConfirm: (graduationDate: Date) => void;
+}
+
+const GenericGraduationDialog = memo(
+  ({ open, title, entityName, isGraduating, onClose, onConfirm }: GenericGraduationDialogProps) => {
+    const [graduationDate, setGraduationDate] = useState<Date | null>(new Date());
+
+    return (
+      <Dialog
+        open={open}
+        disableEscapeKeyDown
+        maxWidth='xs'
+        fullWidth
+        onClose={(_, reason) => {
+          if (reason !== 'backdropClick') onClose();
+        }}
+        aria-labelledby='graduation-dialog-title'
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: (theme) => alpha(theme.palette.success.main, 0.12),
+              color: 'success.main',
+              mb: 3,
+            }}
+          >
+            <RiGraduationCapLine size={28} />
+          </Box>
+          <Typography variant='h6' fontWeight={600} textAlign='center' id='graduation-dialog-title'>
+            {title}
+          </Typography>
+        </Box>
+
+        <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+          <Typography variant='body2' color='text.secondary' sx={{ mb: 4, lineHeight: 1.8 }}>
+            {'บันทึกการจบการศึกษาของ '}
+            <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+              {entityName}
+            </Typography>
+            {' ใช่หรือไม่?'}
+          </Typography>
+          <ThaiDatePicker
+            label='วันที่จบการศึกษา (พ.ศ.)'
+            value={graduationDate}
+            onChange={(date) => setGraduationDate(date)}
+          />
+        </DialogContent>
+
+        <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+          <Button
+            variant='outlined'
+            color='inherit'
+            onClick={onClose}
+            disabled={isGraduating}
+            fullWidth
+            id='graduation-dialog-cancel'
+          >
+            ยกเลิก
+          </Button>
+          <Button
+            variant='contained'
+            color='success'
+            disabled={!graduationDate || isGraduating}
+            onClick={() => graduationDate && onConfirm(graduationDate)}
+            fullWidth
+            id='graduation-dialog-confirm'
+          >
+            {isGraduating ? 'กำลังบันทึก...' : 'ยืนยัน'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  },
+);
+
+GenericGraduationDialog.displayName = 'GenericGraduationDialog';
+
+export default GenericGraduationDialog;

--- a/frontend/src/@core/components/dialogs/index.ts
+++ b/frontend/src/@core/components/dialogs/index.ts
@@ -1,0 +1,4 @@
+export { default as ConfirmDialog } from './ConfirmDialog';
+export { default as GenericDeleteDialog } from './GenericDeleteDialog';
+export { default as GenericGraduationDialog } from './GenericGraduationDialog';
+export type { ConfirmDialogOptions } from './ConfirmDialog';

--- a/frontend/src/components/dialogs/ClassroomDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/ClassroomDeleteDialog.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericDeleteDialog } from '@/@core/components/dialogs';
+
+import type { ClassroomItem } from '@/hooks/queries/useClassrooms';
+
+interface ClassroomDeleteDialogProps {
+  open: boolean;
+  classroom: ClassroomItem | null;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ClassroomDeleteDialog = memo(({ open, classroom, isDeleting, onClose, onConfirm }: ClassroomDeleteDialogProps) => {
+  const name = classroom?.name || 'ห้องเรียน';
+
+  return (
+    <GenericDeleteDialog
+      open={open}
+      title='ยืนยันการลบห้องเรียน'
+      itemName={name}
+      itemIdentifier={classroom?.classroomId}
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      warningMessage='ลบแล้วกู้คืนอัตโนมัติไม่ได้ ระบบจะยอมลบได้เฉพาะห้องเรียนที่ยังไม่มีนักเรียน ครู รายวิชา หรือรายงานเชื่อมอยู่เท่านั้น'
+    />
+  );
+});
+
+ClassroomDeleteDialog.displayName = 'ClassroomDeleteDialog';
+
+export default ClassroomDeleteDialog;

--- a/frontend/src/components/dialogs/DepartmentDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/DepartmentDeleteDialog.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericDeleteDialog } from '@/@core/components/dialogs';
+
+import type { DepartmentItem } from '@/hooks/queries/useDepartments';
+
+interface DepartmentDeleteDialogProps {
+  open: boolean;
+  department: DepartmentItem | null;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DepartmentDeleteDialog = memo(({ open, department, isDeleting, onClose, onConfirm }: DepartmentDeleteDialogProps) => {
+  const name = department?.name || 'สาขาวิชา';
+
+  return (
+    <GenericDeleteDialog
+      open={open}
+      title='ยืนยันการลบสาขาวิชา'
+      itemName={name}
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      warningMessage='ลบแล้วกู้คืนอัตโนมัติไม่ได้'
+    />
+  );
+});
+
+DepartmentDeleteDialog.displayName = 'DepartmentDeleteDialog';
+
+export default DepartmentDeleteDialog;

--- a/frontend/src/components/dialogs/ProgramDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/ProgramDeleteDialog.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericDeleteDialog } from '@/@core/components/dialogs';
+
+import type { ProgramItem } from '@/hooks/queries/usePrograms';
+
+interface ProgramDeleteDialogProps {
+  open: boolean;
+  program: ProgramItem | null;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ProgramDeleteDialog = memo(({ open, program, isDeleting, onClose, onConfirm }: ProgramDeleteDialogProps) => {
+  const name = program?.name || 'หลักสูตร';
+
+  return (
+    <GenericDeleteDialog
+      open={open}
+      title='ยืนยันการลบหลักสูตร'
+      itemName={name}
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      warningMessage='ลบแล้วกู้คืนอัตโนมัติไม่ได้'
+    />
+  );
+});
+
+ProgramDeleteDialog.displayName = 'ProgramDeleteDialog';
+
+export default ProgramDeleteDialog;

--- a/frontend/src/components/dialogs/StudentBulkGraduationDialog.tsx
+++ b/frontend/src/components/dialogs/StudentBulkGraduationDialog.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericGraduationDialog } from '@/@core/components/dialogs';
+
+interface StudentBulkGraduationDialogProps {
+  open: boolean;
+  classroomName: string;
+  studentCount: number;
+  isGraduating: boolean;
+  onClose: () => void;
+  onConfirm: (graduationDate: Date) => void;
+}
+
+const StudentBulkGraduationDialog = memo(({ open, classroomName, studentCount, isGraduating, onClose, onConfirm }: StudentBulkGraduationDialogProps) => {
+  const entityName = `นักเรียน ${studentCount} คน ในห้อง "${classroomName}"`;
+
+  return (
+    <GenericGraduationDialog
+      open={open}
+      title='ยืนยันการจบการศึกษาทั้งห้อง'
+      entityName={entityName}
+      isGraduating={isGraduating}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+});
+
+StudentBulkGraduationDialog.displayName = 'StudentBulkGraduationDialog';
+
+export default StudentBulkGraduationDialog;

--- a/frontend/src/components/dialogs/StudentDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/StudentDeleteDialog.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericDeleteDialog } from '@/@core/components/dialogs';
+
+import type { StudentData } from '@/types/apps/studentTypes';
+
+interface StudentDeleteDialogProps {
+  open: boolean;
+  student: StudentData | null;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const StudentDeleteDialog = memo(({ open, student, isDeleting, onClose, onConfirm }: StudentDeleteDialogProps) => {
+  const fullName = `${student?.user?.account?.title ?? ''}${student?.user?.account?.firstName ?? ''} ${student?.user?.account?.lastName ?? ''}`.trim();
+
+  return (
+    <GenericDeleteDialog
+      open={open}
+      title='ยืนยันการลบข้อมูล'
+      itemName={fullName}
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      warningMessage='การดำเนินการนี้ไม่สามารถย้อนกลับได้'
+    />
+  );
+});
+
+StudentDeleteDialog.displayName = 'StudentDeleteDialog';
+
+export default StudentDeleteDialog;

--- a/frontend/src/components/dialogs/StudentGraduationDialog.tsx
+++ b/frontend/src/components/dialogs/StudentGraduationDialog.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericGraduationDialog } from '@/@core/components/dialogs';
+
+import type { StudentData } from '@/types/apps/studentTypes';
+
+interface StudentGraduationDialogProps {
+  open: boolean;
+  student: StudentData | null;
+  isGraduating: boolean;
+  onClose: () => void;
+  onConfirm: (graduationDate: Date) => void;
+}
+
+const StudentGraduationDialog = memo(({ open, student, isGraduating, onClose, onConfirm }: StudentGraduationDialogProps) => {
+  const fullName = `${student?.user?.account?.title ?? ''}${student?.user?.account?.firstName ?? ''} ${student?.user?.account?.lastName ?? ''}`.trim();
+
+  return (
+    <GenericGraduationDialog
+      open={open}
+      title='ยืนยันการจบการศึกษา'
+      entityName={fullName}
+      isGraduating={isGraduating}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+});
+
+StudentGraduationDialog.displayName = 'StudentGraduationDialog';
+
+export default StudentGraduationDialog;

--- a/frontend/src/components/dialogs/StudentIndividualPromotionDialog.tsx
+++ b/frontend/src/components/dialogs/StudentIndividualPromotionDialog.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { memo } from 'react';
+import { alpha, Box } from '@mui/material';
+import { RiArrowUpLine } from 'react-icons/ri';
+import {
+  Autocomplete,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+interface ClassroomOption {
+  id: string;
+  name: string;
+  classroomId?: string;
+}
+
+interface StudentData {
+  user?: {
+    account?: {
+      title?: string;
+      firstName?: string;
+      lastName?: string;
+    };
+  };
+  classroom?: {
+    name?: string;
+    id?: string;
+  };
+}
+
+interface StudentIndividualPromotionDialogProps {
+  open: boolean;
+  student: StudentData | null;
+  classrooms: ClassroomOption[];
+  targetClassroom: ClassroomOption | null;
+  isPromoting: boolean;
+  onTargetChange: (value: ClassroomOption | null) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const StudentIndividualPromotionDialog = memo(
+  ({
+    open,
+    student,
+    classrooms,
+    targetClassroom,
+    isPromoting,
+    onTargetChange,
+    onConfirm,
+    onCancel,
+  }: StudentIndividualPromotionDialogProps) => {
+    const fullName = student
+      ? `${student.user?.account?.title ?? ''}${student.user?.account?.firstName ?? ''} ${student.user?.account?.lastName ?? ''}`.trim()
+      : '';
+    const currentClassroom = student?.classroom?.name ?? '';
+
+    return (
+      <Dialog
+        open={open}
+        fullWidth
+        maxWidth='xs'
+        onClose={onCancel}
+        aria-labelledby='individual-promotion-dialog-title'
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: '50%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+              color: 'primary.main',
+              mb: 3,
+            }}
+          >
+            <RiArrowUpLine size={28} />
+          </Box>
+          <Typography variant='h6' fontWeight={600} textAlign='center' id='individual-promotion-dialog-title'>
+            เลื่อนชั้นนักเรียน
+          </Typography>
+        </Box>
+
+        <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+          <Typography variant='body2' color='text.secondary' sx={{ mb: 1, lineHeight: 1.8 }}>
+            {'ย้าย '}
+            <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+              {fullName}
+            </Typography>
+            {' จากห้อง '}
+            <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+              {currentClassroom}
+            </Typography>
+            {' ไปยังห้องเรียนปลายทาง'}
+          </Typography>
+          <Autocomplete
+            id='individual-promote-target-classroom'
+            options={classrooms.filter((c) => c.id !== student?.classroom?.id)}
+            getOptionLabel={(option) => option?.name ?? option?.classroomId ?? ''}
+            value={targetClassroom}
+            onChange={(_, value) => onTargetChange(value)}
+            disabled={isPromoting}
+            renderInput={(params) => (
+              <TextField {...params} label='ห้องเรียนปลายทาง' placeholder='เลือกห้องเรียน...' />
+            )}
+            isOptionEqualToValue={(option, value) => option?.id === value?.id}
+            noOptionsText='ไม่พบห้องเรียน'
+            sx={{ mt: 3 }}
+          />
+        </DialogContent>
+
+        <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+          <Button
+            variant='outlined'
+            color='inherit'
+            onClick={onCancel}
+            disabled={isPromoting}
+            fullWidth
+            id='individual-promotion-dialog-cancel'
+          >
+            ยกเลิก
+          </Button>
+          <Button
+            variant='contained'
+            color='primary'
+            onClick={onConfirm}
+            disabled={!targetClassroom || isPromoting}
+            fullWidth
+            id='individual-promotion-dialog-confirm'
+          >
+            {isPromoting ? 'กำลังเลื่อนชั้น...' : 'ยืนยัน'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  },
+);
+
+StudentIndividualPromotionDialog.displayName = 'StudentIndividualPromotionDialog';
+
+export default StudentIndividualPromotionDialog;

--- a/frontend/src/components/dialogs/TeacherDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/TeacherDeleteDialog.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { memo } from 'react';
+
+import { GenericDeleteDialog } from '@/@core/components/dialogs';
+
+interface TeacherDeleteDialogProps {
+  open: boolean;
+  teacher: { title?: string; firstName: string; lastName: string } | null;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const TeacherDeleteDialog = memo(({ open, teacher, isDeleting, onClose, onConfirm }: TeacherDeleteDialogProps) => {
+  const fullName = `${teacher?.title ? teacher?.title : ''}${teacher?.firstName} ${teacher?.lastName}`.trim();
+
+  return (
+    <GenericDeleteDialog
+      open={open}
+      title='ยืนยันการลบข้อมูลครู / บุคลากร'
+      itemName={fullName}
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+});
+
+TeacherDeleteDialog.displayName = 'TeacherDeleteDialog';
+
+export default TeacherDeleteDialog;

--- a/frontend/src/components/dialogs/index.ts
+++ b/frontend/src/components/dialogs/index.ts
@@ -1,0 +1,9 @@
+export { default as StudentDeleteDialog } from './StudentDeleteDialog';
+export { default as StudentGraduationDialog } from './StudentGraduationDialog';
+export { default as StudentBulkGraduationDialog } from './StudentBulkGraduationDialog';
+export { default as StudentIndividualPromotionDialog } from './StudentIndividualPromotionDialog';
+export { default as ClassroomDeleteDialog } from './ClassroomDeleteDialog';
+export { default as ClassroomPromotionDialog } from '@/views/apps/settings/classroom/ClassroomPromotionDialog';
+export { default as DepartmentDeleteDialog } from './DepartmentDeleteDialog';
+export { default as ProgramDeleteDialog } from './ProgramDeleteDialog';
+export { default as TeacherDeleteDialog } from './TeacherDeleteDialog';

--- a/frontend/src/hooks/features/student/useStudentList.tsx
+++ b/frontend/src/hooks/features/student/useStudentList.tsx
@@ -10,12 +10,17 @@ import {
   useStudentsWithParams,
   useDeleteStudent,
   useImportStudents,
+  useGraduateStudent,
+  useGraduateClassroom,
+  usePromoteStudents,
+  usePromotePreview,
   type StudentImportResult,
 } from '@/hooks/queries/useStudents';
 
 interface SearchValue {
   fullName: string;
   studentId: string;
+  studentStatus: string;
 }
 
 interface UseStudentListReturn {
@@ -35,6 +40,29 @@ interface UseStudentListReturn {
   // Delete dialog state
   openDeletedConfirm: boolean;
   deletedStudent: any | null;
+  isDeleting: boolean;
+
+  // Graduation dialog state
+  openGraduationConfirm: boolean;
+  graduationStudent: any | null;
+  isGraduating: boolean;
+
+  // Bulk graduation dialog state
+  openBulkGraduationConfirm: boolean;
+  isGraduatingClassroom: boolean;
+
+  // Promotion dialog state
+  openPromoteConfirm: boolean;
+  promoteSource: any | null;
+  promoteTarget: any | null;
+  promotePreview: any | null;
+  isLoadingPromotePreview: boolean;
+  isPromoting: boolean;
+
+  // Individual promotion dialog state
+  openIndividualPromoteConfirm: boolean;
+  promoteStudent: any | null;
+  promoteStudentTarget: any | null;
 
   // Import state
   openImportResultDialog: boolean;
@@ -51,9 +79,25 @@ interface UseStudentListReturn {
   handleChangeFullName: (e: any, newValue: any) => void;
   handleSearchChange: (event: any, value: any, reason: any) => void;
   handleStudentId: (value: any) => void;
+  handleStatusChange: (status: string) => void;
   handleDeleteClick: (student: any) => void;
-  handleDeleteConfirm: (event: any) => void;
+  handleDeleteConfirm: () => void;
   handleDeleteCancel: () => void;
+  handleGraduationClick: (student: any) => void;
+  handleGraduationConfirm: (graduationDate: Date) => void;
+  handleGraduationCancel: () => void;
+  handleBulkGraduationClick: () => void;
+  handleBulkGraduationConfirm: (graduationDate: Date) => void;
+  handleBulkGraduationCancel: () => void;
+  handlePromoteClick: () => void;
+  handlePromoteSourceChange: (value: any) => void;
+  handlePromoteTargetChange: (value: any) => void;
+  handlePromoteConfirm: () => void;
+  handlePromoteCancel: () => void;
+  handleIndividualPromoteClick: (student: any) => void;
+  handleIndividualPromoteTargetChange: (value: any) => void;
+  handleIndividualPromoteConfirm: () => void;
+  handleIndividualPromoteCancel: () => void;
   handleImportStudents: (file: File | null) => Promise<void>;
   handleCloseImportResultDialog: () => void;
   handleDownloadTemplate: () => Promise<void>;
@@ -105,7 +149,10 @@ export const useStudentList = (): UseStudentListReturn => {
 
   const { data: allClassrooms = [], isLoading: loadingClassroom } = useClassrooms();
   const { mutate: deleteStudent } = useDeleteStudent();
+  const { mutate: graduateStudent } = useGraduateStudent();
+  const { mutate: graduateClassroom } = useGraduateClassroom();
   const { mutateAsync: importStudents, isPending: isImportingStudents } = useImportStudents();
+  const { mutate: promoteStudents, isPending: isPromoting } = usePromoteStudents();
 
   // ─── UI State ────────────────────────────────────────────────────────────────
 
@@ -113,10 +160,26 @@ export const useStudentList = (): UseStudentListReturn => {
   const [currentClassroomId, setCurrentClassroomId] = useState<string | null>(null);
   const classroomInitialized = useRef(false);
   const [currentStudent, setCurrentStudent] = useState<any | null>(null);
-  const [searchValue, setSearchValue] = useState<SearchValue>({ fullName: '', studentId: '' });
+  const [searchValue, setSearchValue] = useState<SearchValue>({ fullName: '', studentId: '', studentStatus: '' });
   const deferredSearchValue = useDeferredValue(searchValue);
   const [openDeletedConfirm, setOpenDeletedConfirm] = useState(false);
   const [deletedStudent, setDeletedStudent] = useState<any | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [openGraduationConfirm, setOpenGraduationConfirm] = useState(false);
+  const [graduationStudent, setGraduationStudent] = useState<any | null>(null);
+  const [isGraduating, setIsGraduating] = useState(false);
+  const [openBulkGraduationConfirm, setOpenBulkGraduationConfirm] = useState(false);
+  const [isGraduatingClassroom, setIsGraduatingClassroom] = useState(false);
+  const [openPromoteConfirm, setOpenPromoteConfirm] = useState(false);
+  const [promoteSource, setPromoteSource] = useState<any | null>(null);
+  const [promoteTarget, setPromoteTarget] = useState<any | null>(null);
+  const [promotePreview, setPromotePreview] = useState<any | null>(null);
+  const { data: promotePreviewData, isLoading: isLoadingPromotePreview } = usePromotePreview(
+    promoteSource?.id ?? null,
+  );
+  const [openIndividualPromoteConfirm, setOpenIndividualPromoteConfirm] = useState(false);
+  const [promoteStudent, setPromoteStudent] = useState<any | null>(null);
+  const [promoteStudentTarget, setPromoteStudentTarget] = useState<any | null>(null);
   const [openImportResultDialog, setOpenImportResultDialog] = useState(false);
   const [importResult, setImportResult] = useState<StudentImportResult | null>(null);
   const [isDownloadingTemplate, setIsDownloadingTemplate] = useState(false);
@@ -145,12 +208,22 @@ export const useStudentList = (): UseStudentListReturn => {
     classroomInitialized.current = true;
   }, [classrooms, classroom]);
 
+  useEffect(() => {
+    if (promotePreviewData) {
+      setPromotePreview(promotePreviewData);
+    }
+  }, [promotePreviewData]);
+
   // ─── Students via React Query ─────────────────────────────────────────────────
 
-  const { data: students = [], isFetching: loadingStudent } = useStudentsWithParams({
-    classroomId: currentClassroomId,
-    search: deferredSearchValue,
-  });
+  const { data: students = [], isFetching: loadingStudent, refetch: refetchStudents } = useStudentsWithParams(
+    {
+      classroomId: currentClassroomId,
+      search: deferredSearchValue,
+      studentStatus: deferredSearchValue.studentStatus || undefined,
+    },
+    { enabled: currentClassroomId !== null },
+  );
 
   // ─── Handlers ────────────────────────────────────────────────────────────────
 
@@ -195,33 +268,208 @@ export const useStudentList = (): UseStudentListReturn => {
     setSearchValue((prev) => ({ ...prev, studentId: value }));
   }, []);
 
+  const handleStatusChange = useCallback((status: string) => {
+    setSearchValue((prev) => ({ ...prev, studentStatus: status }));
+  }, []);
+
   const handleDeleteClick = useCallback((student: any) => {
     setOpenDeletedConfirm(true);
     setDeletedStudent(student);
   }, []);
 
-  const handleDeleteConfirm = useCallback(
-    (event: any) => {
-      event.stopPropagation();
-      setOpenDeletedConfirm(false);
-      const toastId = toast.info('กำลังลบข้อมูล...', { autoClose: false, hideProgressBar: true });
-      deleteStudent(deletedStudent.id, {
-        onSuccess: () => {
-          toast.dismiss(toastId);
-          toast.success('ลบข้อมูลสำเร็จ');
-        },
-        onError: () => {
-          toast.dismiss(toastId);
-          toast.error('เกิดข้อผิดพลาดในการลบข้อมูล');
-        },
-      });
-    },
-    [deletedStudent, deleteStudent],
-  );
+  const handleDeleteConfirm = useCallback(() => {
+    setIsDeleting(true);
+    const toastId = toast.info('กำลังลบข้อมูล...', { autoClose: false, hideProgressBar: true });
+    deleteStudent(deletedStudent.id, {
+      onSuccess: () => {
+        setIsDeleting(false);
+        setOpenDeletedConfirm(false);
+        toast.dismiss(toastId);
+        toast.success('ลบข้อมูลสำเร็จ');
+      },
+      onError: () => {
+        setIsDeleting(false);
+        toast.dismiss(toastId);
+        toast.error('เกิดข้อผิดพลาดในการลบข้อมูล');
+      },
+    });
+  }, [deletedStudent, deleteStudent]);
 
   const handleDeleteCancel = useCallback(() => {
     setOpenDeletedConfirm(false);
     setDeletedStudent(null);
+  }, []);
+
+  const handleGraduationClick = useCallback((student: any) => {
+    setOpenGraduationConfirm(true);
+    setGraduationStudent(student);
+  }, []);
+
+  const handleGraduationConfirm = useCallback(
+    (graduationDate: Date) => {
+      setIsGraduating(true);
+      const graduationYear = graduationDate.getFullYear() + 543;
+      const toastId = toast.info('กำลังบันทึกการจบการศึกษา...', { autoClose: false, hideProgressBar: true });
+      graduateStudent(
+        { studentId: graduationStudent.id, graduationYear, graduationDate },
+        {
+          onSuccess: () => {
+            setIsGraduating(false);
+            setOpenGraduationConfirm(false);
+            toast.dismiss(toastId);
+            toast.success('บันทึกการจบการศึกษาสำเร็จ');
+          },
+          onError: () => {
+            setIsGraduating(false);
+            toast.dismiss(toastId);
+            toast.error('เกิดข้อผิดพลาดในการบันทึกการจบการศึกษา');
+          },
+        },
+      );
+    },
+    [graduationStudent, graduateStudent],
+  );
+
+  const handleGraduationCancel = useCallback(() => {
+    setOpenGraduationConfirm(false);
+    setGraduationStudent(null);
+  }, []);
+
+  const handleBulkGraduationClick = useCallback(() => {
+    setOpenBulkGraduationConfirm(true);
+  }, []);
+
+  const handleBulkGraduationConfirm = useCallback(
+    (graduationDate: Date) => {
+      if (!currentClassroomId) return;
+      setIsGraduatingClassroom(true);
+      const graduationYear = graduationDate.getFullYear() + 543;
+      const toastId = toast.info('กำลังบันทึกการจบการศึกษาทั้งห้อง...', { autoClose: false, hideProgressBar: true });
+      graduateClassroom(
+        { classroomId: currentClassroomId, graduationYear, graduationDate },
+        {
+          onSuccess: (result) => {
+            setIsGraduatingClassroom(false);
+            setOpenBulkGraduationConfirm(false);
+            toast.dismiss(toastId);
+            toast.success(`จบการศึกษา ${result.graduated} คน จากห้อง ${result.classroom} สำเร็จ`);
+          },
+          onError: () => {
+            setIsGraduatingClassroom(false);
+            toast.dismiss(toastId);
+            toast.error('เกิดข้อผิดพลาดในการบันทึกการจบการศึกษา');
+          },
+        },
+      );
+    },
+    [currentClassroomId, graduateClassroom],
+  );
+
+  const handleBulkGraduationCancel = useCallback(() => {
+    setOpenBulkGraduationConfirm(false);
+  }, []);
+
+  const handlePromoteClick = useCallback(() => {
+    setOpenPromoteConfirm(true);
+  }, []);
+
+  const handlePromoteSourceChange = useCallback(
+    (value: any) => {
+      setPromoteSource(value);
+      if (promoteTarget?.id === value?.id) {
+        setPromoteTarget(null);
+      }
+      setPromotePreview(null);
+    },
+    [promoteTarget],
+  );
+
+  const handlePromoteTargetChange = useCallback((value: any) => {
+    setPromoteTarget(value);
+  }, []);
+
+  const handlePromoteConfirm = useCallback(() => {
+    if (!promoteSource?.id || !promoteTarget?.id) return;
+
+    const toastId = toast.info('กำลังเลื่อนชั้นนักเรียน...', {
+      autoClose: false,
+      hideProgressBar: true,
+    });
+
+    promoteStudents(
+      {
+        sourceClassroomId: promoteSource.id,
+        targetClassroomId: promoteTarget.id,
+      },
+      {
+        onSuccess: (result) => {
+          toast.dismiss(toastId);
+          toast.success(`เลื่อนชั้น ${result.promoted} คน สำเร็จ`);
+          setOpenPromoteConfirm(false);
+          setPromoteSource(null);
+          setPromoteTarget(null);
+          setPromotePreview(null);
+          refetchStudents();
+        },
+        onError: () => {
+          toast.dismiss(toastId);
+          toast.error('เกิดข้อผิดพลาดในการเลื่อนชั้นนักเรียน');
+        },
+      },
+    );
+  }, [promoteSource, promoteTarget, promoteStudents, refetchStudents]);
+
+  const handlePromoteCancel = useCallback(() => {
+    setOpenPromoteConfirm(false);
+    setPromoteSource(null);
+    setPromoteTarget(null);
+    setPromotePreview(null);
+  }, []);
+
+  const handleIndividualPromoteClick = useCallback((student: any) => {
+    setPromoteStudent(student);
+    setOpenIndividualPromoteConfirm(true);
+  }, []);
+
+  const handleIndividualPromoteTargetChange = useCallback((value: any) => {
+    setPromoteStudentTarget(value);
+  }, []);
+
+  const handleIndividualPromoteConfirm = useCallback(() => {
+    if (!promoteStudent?.id || !promoteStudentTarget?.id) return;
+
+    const toastId = toast.info('กำลังเลื่อนชั้นนักเรียน...', {
+      autoClose: false,
+      hideProgressBar: true,
+    });
+
+    promoteStudents(
+      {
+        sourceClassroomId: promoteStudent.classroomId,
+        targetClassroomId: promoteStudentTarget.id,
+        studentIds: [promoteStudent.id],
+      },
+      {
+        onSuccess: (result) => {
+          toast.dismiss(toastId);
+          toast.success(`เลื่อนชั้น ${result.promoted} คน สำเร็จ`);
+          setOpenIndividualPromoteConfirm(false);
+          setPromoteStudent(null);
+          setPromoteStudentTarget(null);
+          refetchStudents();
+        },
+        onError: () => {
+          toast.dismiss(toastId);
+          toast.error('เกิดข้อผิดพลาดในการเลื่อนชั้นนักเรียน');
+        },
+      },
+    );
+  }, [promoteStudent, promoteStudentTarget, promoteStudents, refetchStudents]);
+
+  const handleIndividualPromoteCancel = useCallback(() => {
+    setOpenIndividualPromoteConfirm(false);
+    setPromoteStudent(null);
+    setPromoteStudentTarget(null);
   }, []);
 
   const handleCloseImportResultDialog = useCallback(() => {
@@ -371,6 +619,21 @@ export const useStudentList = (): UseStudentListReturn => {
     searchValue,
     openDeletedConfirm,
     deletedStudent,
+    isDeleting,
+    openGraduationConfirm,
+    graduationStudent,
+    isGraduating,
+    openBulkGraduationConfirm,
+    isGraduatingClassroom,
+    openPromoteConfirm,
+    promoteSource,
+    promoteTarget,
+    promotePreview,
+    isLoadingPromotePreview,
+    isPromoting,
+    openIndividualPromoteConfirm,
+    promoteStudent,
+    promoteStudentTarget,
     openImportResultDialog,
     importResult,
     isImportingStudents,
@@ -381,9 +644,25 @@ export const useStudentList = (): UseStudentListReturn => {
     handleChangeFullName,
     handleSearchChange,
     handleStudentId,
+    handleStatusChange,
     handleDeleteClick,
     handleDeleteConfirm,
     handleDeleteCancel,
+    handleGraduationClick,
+    handleGraduationConfirm,
+    handleGraduationCancel,
+    handleBulkGraduationClick,
+    handleBulkGraduationConfirm,
+    handleBulkGraduationCancel,
+    handlePromoteClick,
+    handlePromoteSourceChange,
+    handlePromoteTargetChange,
+    handlePromoteConfirm,
+    handlePromoteCancel,
+    handleIndividualPromoteClick,
+    handleIndividualPromoteTargetChange,
+    handleIndividualPromoteConfirm,
+    handleIndividualPromoteCancel,
     handleImportStudents,
     handleCloseImportResultDialog,
     handleDownloadTemplate,

--- a/frontend/src/hooks/queries/useStudents.ts
+++ b/frontend/src/hooks/queries/useStudents.ts
@@ -223,10 +223,19 @@ export const usePromoteStudents = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ sourceClassroomId, targetClassroomId }: { sourceClassroomId: string; targetClassroomId: string }) => {
+    mutationFn: async ({
+      sourceClassroomId,
+      targetClassroomId,
+      studentIds,
+    }: {
+      sourceClassroomId: string;
+      targetClassroomId: string;
+      studentIds?: string[];
+    }) => {
       const { data } = await httpClient.post(`${authConfig.studentEndpoint}/promote-classroom`, {
         sourceClassroomId,
         targetClassroomId,
+        studentIds,
       });
       return data as PromoteClassroomResult;
     },
@@ -241,7 +250,7 @@ export const usePromoteStudents = () => {
  * Hook to search students with POST params (classroomId + search filters)
  */
 export const useStudentsWithParams = (
-  params: { classroomId: string | null; search: { fullName: string; studentId: string } },
+  params: { classroomId: string | null; search: { fullName: string; studentId: string }; studentStatus?: string },
   options?: { enabled?: boolean },
 ) => {
   return useQuery({
@@ -250,6 +259,7 @@ export const useStudentsWithParams = (
       const { data } = await httpClient.post(`${authConfig.studentEndpoint}/search-with-params`, {
         classroomId: params.classroomId,
         search: params.search,
+        studentStatus: params.studentStatus || undefined,
       });
       return unwrapArrayResponse(data);
     },
@@ -259,17 +269,89 @@ export const useStudentsWithParams = (
   });
 };
 
+export interface GraduateClassroomResult {
+  graduated: number;
+  classroom: string;
+  graduationYear: number;
+}
+
+/**
+ * Hook to graduate all students in a classroom
+ */
+export const useGraduateClassroom = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ classroomId, graduationYear, graduationDate }: { classroomId: string; graduationYear: number; graduationDate: Date }) => {
+      const { data } = await httpClient.post(`${authConfig.studentEndpoint}/graduate-classroom`, {
+        classroomId,
+        graduationYear,
+        graduationDate: graduationDate.toISOString(),
+      });
+      return data as GraduateClassroomResult;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.students.all });
+    },
+  });
+};
+
+/**
+ * Hook to mark a student as graduated
+ */
+export const useGraduateStudent = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ studentId, graduationYear, graduationDate }: { studentId: string; graduationYear: number; graduationDate: Date }) => {
+      const { data } = await httpClient.put(`${authConfig.studentEndpoint}/profile/${studentId}`, {
+        isGraduation: true,
+        graduationYear,
+        graduationDate: graduationDate.toISOString(),
+        studentStatus: 'graduated',
+      });
+      return unwrapResponse(data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.students.all });
+    },
+  });
+};
+
 /**
  * Hook to fetch student trophy overview
+ * Backend returns: { goodnessScore, goodnessCount, badnessScore, badnessCount, netScore }
+ * Normalized to: { goodScore, badScore, totalTrophy, netScore }
  */
 export const useStudentTrophyOverview = (studentId: string) => {
   return useQuery({
     queryKey: queryKeys.students.trophy(studentId),
     queryFn: async () => {
       const { data } = await httpClient.get(`${authConfig.studentEndpoint}/trophy-overview/${studentId}`);
-      return unwrapResponse(data);
+      const raw = unwrapResponse<any>(data);
+      return {
+        goodScore: raw?.goodnessScore ?? 0,
+        badScore: raw?.badnessScore ?? 0,
+        totalTrophy: raw?.goodnessCount ?? 0,
+        netScore: raw?.netScore ?? 0,
+      };
     },
     enabled: !!studentId,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+/**
+ * Hook to fetch teachers for a student's classroom
+ */
+export const useStudentClassroomTeachers = (classroomId: string) => {
+  return useQuery({
+    queryKey: [...queryKeys.students.all, 'classroom-teachers', classroomId] as const,
+    queryFn: async () => {
+      const { data } = await httpClient.get(`${authConfig.studentEndpoint}/classroom/${classroomId}/teacher`);
+      return unwrapArrayResponse<any>(data);
+    },
+    enabled: !!classroomId,
     staleTime: 5 * 60 * 1000,
   });
 };

--- a/frontend/src/views/apps/admin/teacher/DialogDeleteTeacher.tsx
+++ b/frontend/src/views/apps/admin/teacher/DialogDeleteTeacher.tsx
@@ -1,15 +1,13 @@
-import IconifyIcon from '@/@core/components/icon';
+import { alpha, Box, Typography } from '@mui/material';
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
-  DialogTitle,
-  IconButton,
-  styled,
 } from '@mui/material';
 import React from 'react';
+
+import IconifyIcon from '@/@core/components/icon';
 
 type Props = {
   data: any;
@@ -18,55 +16,51 @@ type Props = {
   open: boolean;
 };
 
-const BootstrapDialog = styled(Dialog)(({ theme }) => ({
-  '& .MuiDialogContent-root': {
-    padding: theme.spacing(2),
-  },
-  '& .MuiDialogActions-root': {
-    padding: theme.spacing(1),
-  },
-}));
-
 const DialogDeleteTeacher = (props: Props) => {
   const { data, onClose, onSubmitted, open } = props;
   const fullName = `${data?.title ? data?.title : ''}${data?.firstName} ${data?.lastName}`;
   return (
-    <BootstrapDialog
-      fullWidth
-      maxWidth='xs'
-      onClose={onClose}
-      aria-labelledby='ยืนยันการลบข้อมูลครู / บุคลากร'
-      open={open}
-    >
-      {onClose ? (
-        <IconButton
-          aria-label='close'
-          onClick={onClose}
+    <Dialog fullWidth maxWidth='xs' onClose={onClose} aria-labelledby='ยืนยันการลบข้อมูลครู / บุคลากร' open={open}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+        <Box
           sx={{
-            position: 'absolute',
-            right: 8,
-            top: 8,
-            color: (theme) => theme.palette.grey[500],
+            width: 56,
+            height: 56,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette.error.main, 0.12),
+            color: 'error.main',
+            mb: 3,
           }}
         >
-          <IconifyIcon icon='mdi:close' />
-        </IconButton>
-      ) : null}
-      <DialogTitle id='alert-dialog-title-goodness'>ยืนยันการลบข้อมูลครู / บุคลากร</DialogTitle>
-      <DialogContent>
-        <DialogContentText id='alert-delete-badness' p={5}>
-          {`คุณต้องการลบข้อมูลของ ${fullName} ใช่หรือไม่?`}
-        </DialogContentText>
+          <IconifyIcon icon='tabler:trash' fontSize={28} />
+        </Box>
+        <Typography variant='h6' fontWeight={600} textAlign='center'>
+          ยืนยันการลบข้อมูลครู / บุคลากร
+        </Typography>
+      </Box>
+
+      <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+        <Typography variant='body2' color='text.secondary' sx={{ lineHeight: 1.8 }}>
+          {'คุณต้องการลบข้อมูลของ '}
+          <Box component='strong' sx={{ color: 'text.primary' }}>
+            {fullName}
+          </Box>
+          {' ใช่หรือไม่?'}
+        </Typography>
       </DialogContent>
-      <DialogActions className='dialog-badness-dense'>
-        <Button color='secondary' onClick={onClose}>
+
+      <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+        <Button variant='outlined' color='inherit' onClick={onClose} fullWidth>
           ยกเลิก
         </Button>
-        <Button variant='contained' color='error' onClick={onSubmitted}>
-          ยืนยัน
+        <Button variant='contained' color='error' onClick={onSubmitted} fullWidth>
+          ลบข้อมูล
         </Button>
       </DialogActions>
-    </BootstrapDialog>
+    </Dialog>
   );
 };
 

--- a/frontend/src/views/apps/settings/classroom/ClassroomDeleteDialog.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomDeleteDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { alpha, Box } from '@mui/material';
 import {
   Alert,
   AlertTitle,
@@ -7,9 +8,10 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogTitle,
   Typography,
 } from '@mui/material';
+
+import Icon from '@/@core/components/icon';
 
 import type { ClassroomItem } from '@/hooks/queries/useClassrooms';
 
@@ -24,22 +26,47 @@ interface ClassroomDeleteDialogProps {
 const ClassroomDeleteDialog = ({ open, classroom, isDeleting, onClose, onConfirm }: ClassroomDeleteDialogProps) => {
   return (
     <Dialog open={open} fullWidth maxWidth='xs' onClose={isDeleting ? undefined : onClose}>
-      <DialogTitle>ยืนยันการลบห้องเรียน</DialogTitle>
-      <DialogContent>
-        <Typography variant='body2' sx={{ mb: 3 }}>
-          คุณกำลังจะลบ <strong>{classroom?.name || 'ห้องเรียน'}</strong>{' '}
-          {classroom?.classroomId ? `(${classroom.classroomId})` : ''} ออกจากระบบ
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette.error.main, 0.12),
+            color: 'error.main',
+            mb: 3,
+          }}
+        >
+          <Icon icon='tabler:trash' fontSize={28} />
+        </Box>
+        <Typography variant='h6' fontWeight={600} textAlign='center'>
+          ยืนยันการลบห้องเรียน
         </Typography>
-        <Alert severity='warning'>
+      </Box>
+
+      <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+        <Typography variant='body2' color='text.secondary' sx={{ mb: 3, lineHeight: 1.8 }}>
+          {'คุณกำลังจะลบ '}
+          <Box component='strong' sx={{ color: 'text.primary' }}>
+            {classroom?.name || 'ห้องเรียน'}
+            {classroom?.classroomId ? ` (${classroom.classroomId})` : ''}
+          </Box>
+          {' ออกจากระบบ'}
+        </Typography>
+        <Alert severity='warning' sx={{ borderRadius: 2 }}>
           <AlertTitle>ลบแล้วกู้คืนอัตโนมัติไม่ได้</AlertTitle>
           ระบบจะยอมลบได้เฉพาะห้องเรียนที่ยังไม่มีนักเรียน ครู รายวิชา หรือรายงานเชื่อมอยู่เท่านั้น
         </Alert>
       </DialogContent>
-      <DialogActions sx={{ px: 6, pb: 5, pt: 1 }}>
-        <Button color='secondary' variant='outlined' onClick={onClose} disabled={isDeleting}>
+
+      <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+        <Button variant='outlined' color='inherit' onClick={onClose} disabled={isDeleting} fullWidth>
           ยกเลิก
         </Button>
-        <Button color='error' variant='contained' onClick={onConfirm} disabled={isDeleting}>
+        <Button variant='contained' color='error' onClick={onConfirm} disabled={isDeleting} fullWidth>
           ลบห้องเรียน
         </Button>
       </DialogActions>

--- a/frontend/src/views/apps/settings/classroom/ClassroomPromotionDialog.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomPromotionDialog.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { alpha, Box } from '@mui/material';
+import { RiArrowUpLine } from 'react-icons/ri';
+import {
+  Alert,
+  Autocomplete,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { RiArrowDownLine } from 'react-icons/ri';
+
+const CONTROL_SX = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '12px',
+  },
+};
+
+interface StudentPromotionDialogProps {
+  open: boolean;
+  classrooms: any[];
+  promoteSource: any | null;
+  promoteTarget: any | null;
+  promotePreview: any | null;
+  isLoadingPreview: boolean;
+  isPromoting: boolean;
+  onSourceChange: (value: any) => void;
+  onTargetChange: (value: any) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ClassroomPromotionDialog = ({
+  open,
+  classrooms,
+  promoteSource,
+  promoteTarget,
+  promotePreview,
+  isLoadingPreview,
+  isPromoting,
+  onSourceChange,
+  onTargetChange,
+  onConfirm,
+  onCancel,
+}: StudentPromotionDialogProps) => {
+  return (
+    <Dialog
+      id='promote-students-dialog'
+      open={open}
+      fullWidth
+      maxWidth='sm'
+      aria-labelledby='promotion-dialog-title'
+      slotProps={{
+        paper: {
+          sx: {
+            overflow: 'hidden',
+          },
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 3,
+          px: 6,
+          pt: 6,
+          pb: 4,
+          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.02),
+        }}
+      >
+        <Box
+          sx={{
+            width: 48,
+            height: 48,
+            borderRadius: '50%',
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+            color: 'primary.main',
+          }}
+        >
+          <RiArrowUpLine size={24} />
+        </Box>
+        <Box>
+          <Typography variant='h6' fontWeight={600} id='promotion-dialog-title'>
+            เลื่อนชั้นนักเรียน
+          </Typography>
+          <Typography variant='body2' color='text.secondary'>
+            นักเรียนทุกคนในห้องเรียนต้นทาง (ยกเว้นที่จบการศึกษาแล้ว) จะถูกย้ายไปยังห้องเรียนปลายทาง
+          </Typography>
+        </Box>
+      </Box>
+
+      <DialogContent sx={{ pt: 4, pb: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 0.5 }}>
+              <Box
+                sx={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
+                  fontSize: '0.75rem',
+                  fontWeight: 700,
+                }}
+              >
+                1
+              </Box>
+              <Typography variant='subtitle2' fontWeight={600}>
+                เลือกห้องเรียนต้นทาง
+              </Typography>
+            </Box>
+
+            <Autocomplete
+              id='promote-source-classroom'
+              options={classrooms.filter((c) => c.id !== promoteTarget?.id)}
+              getOptionLabel={(option) => option?.name ?? option?.classroomId ?? ''}
+              value={promoteSource}
+              onChange={(_, value) => onSourceChange(value)}
+              disabled={isPromoting}
+              renderInput={(params) => (
+                <TextField {...params} label='ห้องเรียนต้นทาง' placeholder='พิมพ์เพื่อค้นหา...' sx={CONTROL_SX} />
+              )}
+              isOptionEqualToValue={(option, value) => option?.id === value?.id}
+              noOptionsText='ไม่พบห้องเรียน'
+            />
+
+            {promoteSource && (
+              <Box
+                sx={{
+                  p: 2.5,
+                  borderRadius: 2,
+                  bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
+                  border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+                }}
+              >
+                {isLoadingPreview ? (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 1 }}>
+                    <CircularProgress size={16} />
+                    <Typography variant='body2' color='text.secondary'>กำลังโหลดรายชื่อ...</Typography>
+                  </Box>
+                ) : promotePreview?.total === 0 ? (
+                  <Alert severity='warning' sx={{ borderRadius: 2 }}>
+                    ไม่มีนักเรียนในห้องเรียนนี้ที่จะเลื่อนชั้นได้
+                  </Alert>
+                ) : promotePreview && promotePreview.total > 0 ? (
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}>
+                      <Typography variant='subtitle2' fontWeight={600}>
+                        นักเรียนที่จะเลื่อนชั้น
+                      </Typography>
+                      <Chip
+                        size='small'
+                        label={`${promotePreview.total} คน`}
+                        sx={{
+                          bgcolor: 'primary.main',
+                          color: 'primary.contrastText',
+                          fontWeight: 600,
+                          '& .MuiChip-label': { px: 1 },
+                        }}
+                      />
+                    </Box>
+                    <Box
+                      sx={{
+                        maxHeight: 180,
+                        overflowY: 'auto',
+                        bgcolor: 'background.paper',
+                        border: (theme) => `1px solid ${theme.palette.divider}`,
+                        borderRadius: 1.5,
+                      }}
+                    >
+                      <List disablePadding dense>
+                        {promotePreview.students.map((student: any, index: number) => (
+                          <ListItem
+                            key={student.id}
+                            divider={index < promotePreview.students.length - 1}
+                            sx={{ py: 0.75, px: 2 }}
+                          >
+                            <ListItemText
+                              primary={student.name}
+                              secondary={student.studentId ?? '-'}
+                              slotProps={{
+                                primary: { variant: 'body2', fontWeight: 500 },
+                                secondary: { variant: 'caption' },
+                              }}
+                            />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  </Box>
+                ) : null}
+              </Box>
+            )}
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 1 }}>
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+                color: 'primary.main',
+                border: (theme) => `2px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+              }}
+            >
+              <RiArrowDownLine size={20} />
+            </Box>
+          </Box>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 0.5 }}>
+              <Box
+                sx={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+                  color: 'primary.main',
+                  fontSize: '0.75rem',
+                  fontWeight: 700,
+                }}
+              >
+                2
+              </Box>
+              <Typography variant='subtitle2' fontWeight={600}>
+                เลือกห้องเรียนปลายทาง
+              </Typography>
+            </Box>
+
+            <Autocomplete
+              id='promote-target-classroom'
+              options={classrooms.filter((c) => c.id !== promoteSource?.id)}
+              getOptionLabel={(option) => option?.name ?? option?.classroomId ?? ''}
+              value={promoteTarget}
+              onChange={(_, value) => onTargetChange(value)}
+              disabled={isPromoting || !promoteSource || promotePreview?.total === 0}
+              renderInput={(params) => (
+                <TextField {...params} label='ห้องเรียนปลายทาง' placeholder='พิมพ์เพื่อค้นหา...' sx={CONTROL_SX} />
+              )}
+              isOptionEqualToValue={(option, value) => option?.id === value?.id}
+              noOptionsText='ไม่พบห้องเรียน'
+            />
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 6, pb: 5, pt: 3, gap: 2 }}>
+        <Button
+          variant='outlined'
+          color='inherit'
+          onClick={onCancel}
+          disabled={isPromoting}
+          fullWidth
+          id='promotion-dialog-cancel'
+        >
+          ยกเลิก
+        </Button>
+        <Button
+          variant='contained'
+          color='primary'
+          onClick={onConfirm}
+          disabled={!promoteSource || !promoteTarget || isPromoting || promotePreview?.total === 0}
+          fullWidth
+          id='promotion-dialog-confirm'
+        >
+          {isPromoting ? 'กำลังเลื่อนชั้น...' : 'ยืนยันเลื่อนชั้น'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ClassroomPromotionDialog;

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -2,7 +2,6 @@
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import Autocomplete from '@mui/material/Autocomplete';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -10,12 +9,10 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Chip from '@mui/material/Chip';
-import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
@@ -47,8 +44,9 @@ import {
 import { useDepartments, useLevels, usePrograms } from '@/hooks/queries/useDepartments';
 import { usePromoteStudents, usePromotePreview } from '@/hooks/queries/useStudents';
 
-import ClassroomDeleteDialog from './ClassroomDeleteDialog';
+import ClassroomDeleteDialog from '@/components/dialogs/ClassroomDeleteDialog';
 import ClassroomFormDialog from './ClassroomFormDialog';
+import ClassroomPromotionDialog from './ClassroomPromotionDialog';
 
 const PANEL_RADIUS = 16;
 const SECTION_RADIUS = 14;
@@ -1148,126 +1146,23 @@ const ClassroomSettingsPage = () => {
         </DialogActions>
       </Dialog>
 
-      <Dialog
-        id='promote-students-dialog'
+
+      <ClassroomPromotionDialog
         open={openPromote}
-        fullWidth
-        maxWidth='sm'
-      >
-        <DialogTitle>เลื่อนชั้นนักเรียน</DialogTitle>
-        <DialogContent sx={{ pt: '16px !important' }}>
-          <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
-            นักเรียนทุกคนในห้องเรียนต้นทาง (ยกเว้นที่จบการศึกษาแล้ว) จะถูกย้ายไปยังห้องเรียนปลายทาง
-          </Typography>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            <Autocomplete
-              id='promote-source-classroom'
-              options={classrooms.filter((c) => c.id !== promoteTarget?.id)}
-              getOptionLabel={(option) => option.name ?? option.classroomId ?? ''}
-              value={promoteSource}
-              onChange={(_, value) => {
-                setPromoteSource(value);
-                if (promoteTarget?.id === value?.id) setPromoteTarget(null);
-              }}
-              disabled={isPromoting}
-              renderInput={(params) => (
-                <TextField {...params} label='ห้องเรียนต้นทาง' placeholder='พิมพ์เพื่อค้นหา...' sx={CONTROL_SX} />
-              )}
-              isOptionEqualToValue={(option, value) => option.id === value.id}
-              noOptionsText='ไม่พบห้องเรียน'
-            />
-
-            {promoteSource && (
-              <Box>
-                {isLoadingPreview ? (
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 1 }}>
-                    <CircularProgress size={16} />
-                    <Typography variant='body2' color='text.secondary'>กำลังโหลดรายชื่อ...</Typography>
-                  </Box>
-                ) : promotePreview?.total === 0 ? (
-                  <Alert severity='warning' sx={{ borderRadius: 2 }}>
-                    ไม่มีนักเรียนในห้องเรียนนี้ที่จะเลื่อนชั้นได้
-                  </Alert>
-                ) : promotePreview && promotePreview.total > 0 ? (
-                  <Box>
-                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-                      <Typography variant='subtitle2'>
-                        รายชื่อนักเรียนที่จะเลื่อนชั้น
-                      </Typography>
-                      <Chip size='small' label={`${promotePreview.total} คน`} color='primary' variant='outlined' />
-                    </Box>
-                    <Box
-                      sx={{
-                        maxHeight: 200,
-                        overflowY: 'auto',
-                        border: (theme) => `1px solid ${theme.palette.divider}`,
-                        borderRadius: 2,
-                      }}
-                    >
-                      <List disablePadding dense>
-                        {promotePreview.students.map((student, index) => (
-                          <ListItem
-                            key={student.id}
-                            divider={index < promotePreview.students.length - 1}
-                            sx={{ py: 0.75 }}
-                          >
-                            <ListItemText
-                              primary={student.name}
-                              secondary={student.studentId ?? '-'}
-                              slotProps={{
-                                primary: { variant: 'body2', fontWeight: 500 },
-                                secondary: { variant: 'caption' },
-                              }}
-                            />
-                          </ListItem>
-                        ))}
-                      </List>
-                    </Box>
-                  </Box>
-                ) : null}
-              </Box>
-            )}
-
-            <Divider />
-
-            <Autocomplete
-              id='promote-target-classroom'
-              options={classrooms.filter((c) => c.id !== promoteSource?.id)}
-              getOptionLabel={(option) => option.name ?? option.classroomId ?? ''}
-              value={promoteTarget}
-              onChange={(_, value) => setPromoteTarget(value)}
-              disabled={isPromoting || !promoteSource || promotePreview?.total === 0}
-              renderInput={(params) => (
-                <TextField {...params} label='ห้องเรียนปลายทาง' placeholder='พิมพ์เพื่อค้นหา...' sx={CONTROL_SX} />
-              )}
-              isOptionEqualToValue={(option, value) => option.id === value.id}
-              noOptionsText='ไม่พบห้องเรียน'
-            />
-          </Box>
-        </DialogContent>
-        <DialogActions sx={{ px: 6, pb: 5, pt: 1 }}>
-          <Button
-            id='promote-cancel-button'
-            variant='outlined'
-            color='error'
-            onClick={() => setOpenPromote(false)}
-            disabled={isPromoting}
-          >
-            ยกเลิก
-          </Button>
-          <Button
-            id='promote-confirm-button'
-            variant='contained'
-            color='primary'
-            onClick={handleConfirmPromote}
-            disabled={!promoteSource || !promoteTarget || isPromoting || promotePreview?.total === 0}
-          >
-            {isPromoting ? 'กำลังเลื่อนชั้น...' : 'ยืนยันเลื่อนชั้น'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      <input ref={fileInputRef} hidden type='file' accept='.xlsx' onChange={handleImportFile} />
+        classrooms={classrooms}
+        promoteSource={promoteSource}
+        promoteTarget={promoteTarget}
+        promotePreview={promotePreview}
+        isLoadingPreview={isLoadingPreview}
+        isPromoting={isPromoting}
+        onSourceChange={(value) => {
+          setPromoteSource(value);
+          if (promoteTarget?.id === value?.id) setPromoteTarget(null);
+        }}
+        onTargetChange={setPromoteTarget}
+        onConfirm={handleConfirmPromote}
+        onCancel={() => setOpenPromote(false)}
+      />
     </>
   );
 };

--- a/frontend/src/views/apps/settings/department/DepartmentDeleteDialog.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentDeleteDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { alpha, Box } from '@mui/material';
 import {
   Alert,
   AlertTitle,
@@ -7,9 +8,10 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogTitle,
   Typography,
 } from '@mui/material';
+
+import Icon from '@/@core/components/icon';
 
 import type { DepartmentItem } from '@/hooks/queries/useDepartments';
 
@@ -24,22 +26,47 @@ interface DepartmentDeleteDialogProps {
 const DepartmentDeleteDialog = ({ open, department, isDeleting, onClose, onConfirm }: DepartmentDeleteDialogProps) => {
   return (
     <Dialog open={open} fullWidth maxWidth='xs' onClose={isDeleting ? undefined : onClose}>
-      <DialogTitle>ยืนยันการลบแผนกวิชา</DialogTitle>
-      <DialogContent>
-        <Typography variant='body2' sx={{ mb: 3 }}>
-          คุณกำลังจะลบ <strong>{department?.name || 'แผนกวิชา'}</strong>{' '}
-          {department?.departmentId ? `(${department.departmentId})` : ''} ออกจากระบบ
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette.error.main, 0.12),
+            color: 'error.main',
+            mb: 3,
+          }}
+        >
+          <Icon icon='tabler:trash' fontSize={28} />
+        </Box>
+        <Typography variant='h6' fontWeight={600} textAlign='center'>
+          ยืนยันการลบแผนกวิชา
         </Typography>
-        <Alert severity='warning'>
+      </Box>
+
+      <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+        <Typography variant='body2' color='text.secondary' sx={{ mb: 3, lineHeight: 1.8 }}>
+          {'คุณกำลังจะลบ '}
+          <Box component='strong' sx={{ color: 'text.primary' }}>
+            {department?.name || 'แผนกวิชา'}
+            {department?.departmentId ? ` (${department.departmentId})` : ''}
+          </Box>
+          {' ออกจากระบบ'}
+        </Typography>
+        <Alert severity='warning' sx={{ borderRadius: 2 }}>
           <AlertTitle>ลบแล้วกู้คืนอัตโนมัติไม่ได้</AlertTitle>
           ระบบจะยอมลบได้เฉพาะแผนกที่ยังไม่มีครู นักเรียน สาขา หรือห้องเรียนเชื่อมอยู่เท่านั้น
         </Alert>
       </DialogContent>
-      <DialogActions sx={{ px: 6, pb: 5, pt: 1 }}>
-        <Button color='secondary' variant='outlined' onClick={onClose} disabled={isDeleting}>
+
+      <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+        <Button variant='outlined' color='inherit' onClick={onClose} disabled={isDeleting} fullWidth>
           ยกเลิก
         </Button>
-        <Button color='error' variant='contained' onClick={onConfirm} disabled={isDeleting}>
+        <Button variant='contained' color='error' onClick={onConfirm} disabled={isDeleting} fullWidth>
           ลบแผนก
         </Button>
       </DialogActions>

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -44,7 +44,7 @@ import {
   type DepartmentPayload,
 } from '@/hooks/queries/useDepartments';
 
-import DepartmentDeleteDialog from './DepartmentDeleteDialog';
+import DepartmentDeleteDialog from '@/components/dialogs/DepartmentDeleteDialog';
 import DepartmentFormDialog from './DepartmentFormDialog';
 
 const PANEL_RADIUS = 16;

--- a/frontend/src/views/apps/settings/program/ProgramDeleteDialog.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramDeleteDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { alpha, Box } from '@mui/material';
 import {
   Alert,
   AlertTitle,
@@ -7,9 +8,10 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogTitle,
   Typography,
 } from '@mui/material';
+
+import Icon from '@/@core/components/icon';
 
 import type { ProgramItem } from '@/hooks/queries/useDepartments';
 
@@ -24,22 +26,47 @@ interface ProgramDeleteDialogProps {
 const ProgramDeleteDialog = ({ open, program, isDeleting, onClose, onConfirm }: ProgramDeleteDialogProps) => {
   return (
     <Dialog open={open} fullWidth maxWidth='xs' onClose={isDeleting ? undefined : onClose}>
-      <DialogTitle>ยืนยันการลบสาขาวิชา</DialogTitle>
-      <DialogContent>
-        <Typography variant='body2' sx={{ mb: 3 }}>
-          คุณกำลังจะลบ <strong>{program?.name || 'สาขาวิชา'}</strong>{' '}
-          {program?.programId ? `(${program.programId})` : ''} ออกจากระบบ
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', px: 6, pt: 6, pb: 2 }}>
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: (theme) => alpha(theme.palette.error.main, 0.12),
+            color: 'error.main',
+            mb: 3,
+          }}
+        >
+          <Icon icon='tabler:trash' fontSize={28} />
+        </Box>
+        <Typography variant='h6' fontWeight={600} textAlign='center'>
+          ยืนยันการลบสาขาวิชา
         </Typography>
-        <Alert severity='warning'>
+      </Box>
+
+      <DialogContent sx={{ px: 6, pt: 2, pb: 4, textAlign: 'center' }}>
+        <Typography variant='body2' color='text.secondary' sx={{ mb: 3, lineHeight: 1.8 }}>
+          {'คุณกำลังจะลบ '}
+          <Box component='strong' sx={{ color: 'text.primary' }}>
+            {program?.name || 'สาขาวิชา'}
+            {program?.programId ? ` (${program.programId})` : ''}
+          </Box>
+          {' ออกจากระบบ'}
+        </Typography>
+        <Alert severity='warning' sx={{ borderRadius: 2 }}>
           <AlertTitle>ลบแล้วกู้คืนอัตโนมัติไม่ได้</AlertTitle>
           ระบบจะยอมลบได้เฉพาะสาขาที่ยังไม่มีนักเรียน ครู ห้องเรียน หรือรายวิชาเชื่อมอยู่เท่านั้น
         </Alert>
       </DialogContent>
-      <DialogActions sx={{ px: 6, pb: 5, pt: 1 }}>
-        <Button color='secondary' variant='outlined' onClick={onClose} disabled={isDeleting}>
+
+      <DialogActions sx={{ px: 6, pb: 6, gap: 2 }}>
+        <Button variant='outlined' color='inherit' onClick={onClose} disabled={isDeleting} fullWidth>
           ยกเลิก
         </Button>
-        <Button color='error' variant='contained' onClick={onConfirm} disabled={isDeleting}>
+        <Button variant='contained' color='error' onClick={onConfirm} disabled={isDeleting} fullWidth>
           ลบสาขา
         </Button>
       </DialogActions>

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -46,7 +46,7 @@ import {
   type ProgramPayload,
 } from '@/hooks/queries/useDepartments';
 
-import ProgramDeleteDialog from './ProgramDeleteDialog';
+import ProgramDeleteDialog from '@/components/dialogs/ProgramDeleteDialog';
 import ProgramFormDialog from './ProgramFormDialog';
 
 const PANEL_RADIUS = 16;

--- a/frontend/src/views/apps/student/edit/StudentEditPage.tsx
+++ b/frontend/src/views/apps/student/edit/StudentEditPage.tsx
@@ -21,7 +21,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { Controller, useForm } from 'react-hook-form';
 import { useState, useEffect, type ChangeEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'react-toastify';
 import { useStudent, useUpdateStudent } from '@/hooks/queries/useStudents';
@@ -168,7 +168,10 @@ const AnimatedGrid = animated(Grid);
 
 const StudentEditPage = ({ id }: StudentEditPageProps) => {
   const [imgSrc, setImgSrc] = useState<string>('/images/avatars/1.png');
-  const { back } = useRouter();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const classroomParam = searchParams.get('classroom');
+  const backHref = classroomParam ? `/apps/student/list?classroom=${classroomParam}` : '/apps/student/list';
 
   // React Query hooks
   const { data: studentData, isLoading } = useStudent(id);
@@ -285,7 +288,7 @@ const StudentEditPage = ({ id }: StudentEditPageProps) => {
       {
         onSuccess: () => {
           toast.success('ข้อมูลนักเรียนได้รับการแก้ไขแล้ว');
-          back();
+          router.push(backHref);
         },
         onError: (error) => {
           console.error('Error updating student:', error);
@@ -717,7 +720,7 @@ const StudentEditPage = ({ id }: StudentEditPageProps) => {
                     id='student-edit-cancel-btn'
                     variant='outlined'
                     color='secondary'
-                    onClick={() => back()}
+                    onClick={() => router.push(backHref)}
                     sx={{
                       minHeight: 50,
                       px: { xs: 3, sm: 4.5 },

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -10,32 +10,32 @@ import CardHeader from '@mui/material/CardHeader';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
 import React, { memo, useMemo, useCallback } from 'react';
-import { RiContactsBookLine, RiUserSearchLine, RiUserUnfollowLine } from 'react-icons/ri';
+import { RiContactsBookLine, RiUserSearchLine, RiUserUnfollowLine, RiGraduationCapLine, RiArrowUpLine } from 'react-icons/ri';
 import { AccountEditOutline } from 'mdi-material-ui';
-import Link from 'next/link';
-
 import CustomNoRowsOverlay from '@/@core/components/check-in/CustomNoRowsOverlay';
 import RenderAvatar from '@/@core/components/avatar';
 import TableHeader from '@/views/apps/student/list/TableHeader';
+import ClassroomPromotionDialog from '@/views/apps/settings/classroom/ClassroomPromotionDialog';
+import StudentDeleteDialog from '@/components/dialogs/StudentDeleteDialog';
+import StudentGraduationDialog from '@/components/dialogs/StudentGraduationDialog';
+import StudentBulkGraduationDialog from '@/components/dialogs/StudentBulkGraduationDialog';
+import StudentIndividualPromotionDialog from '@/components/dialogs/StudentIndividualPromotionDialog';
 import { useStudentList } from '@/hooks/features/student';
 import type { StudentImportResult } from '@/hooks/queries/useStudents';
 
 // ─── Styled Components ────────────────────────────────────────────────────────
-
-const LinkStyled = styled(Link)(({ theme }) => ({
-  textDecoration: 'none',
-  color: theme.palette.primary.main,
-}));
 
 const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   border: 0,
@@ -106,40 +106,6 @@ const StudentNameCell = memo(({ row }: { row: any }) => (
       </Typography>
     </Box>
   </Box>
-));
-
-interface StudentDeleteDialogProps {
-  open: boolean;
-  student: any;
-  onConfirm: (event: any) => void;
-  onCancel: () => void;
-}
-
-const StudentDeleteDialog = memo(({ open, student, onConfirm, onCancel }: StudentDeleteDialogProps) => (
-  <Dialog
-    open={open}
-    disableEscapeKeyDown
-    aria-labelledby='alert-dialog-title'
-    aria-describedby='alert-dialog-description'
-    onClose={(_, reason) => {
-      if (reason !== 'backdropClick') onCancel();
-    }}
-  >
-    <DialogTitle id='alert-dialog-title'>ยืนยันการลบข้อมูล</DialogTitle>
-    <DialogContent>
-      <DialogContentText id='alert-dialog-description'>
-        {`คุณต้องการลบข้อมูลของ ${student?.user?.account?.title}${student?.user?.account?.firstName} ${student?.user?.account?.lastName} ใช่หรือไม่?`}
-      </DialogContentText>
-    </DialogContent>
-    <DialogActions className='dialog-actions-dense'>
-      <Button color='secondary' onClick={onCancel}>
-        ยกเลิก
-      </Button>
-      <Button variant='outlined' color='error' onClick={onConfirm}>
-        ยืนยัน
-      </Button>
-    </DialogActions>
-  </Dialog>
 ));
 
 interface StudentImportResultDialogProps {
@@ -255,6 +221,21 @@ const StudentListPage = () => {
     searchValue,
     openDeletedConfirm,
     deletedStudent,
+    isDeleting,
+    openGraduationConfirm,
+    graduationStudent,
+    isGraduating,
+    openBulkGraduationConfirm,
+    isGraduatingClassroom,
+    openPromoteConfirm,
+    promoteSource,
+    promoteTarget,
+    promotePreview,
+    isLoadingPromotePreview,
+    isPromoting,
+    openIndividualPromoteConfirm,
+    promoteStudent,
+    promoteStudentTarget,
     openImportResultDialog,
     importResult,
     isImportingStudents,
@@ -266,9 +247,25 @@ const StudentListPage = () => {
     handleChangeFullName,
     handleSearchChange,
     handleStudentId,
+    handleStatusChange,
     handleDeleteClick,
     handleDeleteConfirm,
     handleDeleteCancel,
+    handleGraduationClick,
+    handleGraduationConfirm,
+    handleGraduationCancel,
+    handleBulkGraduationClick,
+    handleBulkGraduationConfirm,
+    handleBulkGraduationCancel,
+    handlePromoteClick,
+    handlePromoteSourceChange,
+    handlePromoteTargetChange,
+    handlePromoteConfirm,
+    handlePromoteCancel,
+    handleIndividualPromoteClick,
+    handleIndividualPromoteTargetChange,
+    handleIndividualPromoteConfirm,
+    handleIndividualPromoteCancel,
     handleImportStudents,
     handleCloseImportResultDialog,
     handleDownloadTemplate,
@@ -309,62 +306,91 @@ const StudentListPage = () => {
         ),
       },
       {
-        flex: 0.15,
-        minWidth: 120,
-        field: 'edited',
-        headerName: 'แก้ไข',
-        editable: false,
+        flex: 0.24,
+        minWidth: 220,
+        field: 'actions',
+        headerName: 'การดำเนินการ',
         sortable: false,
-        hideSortIcons: true,
         filterable: false,
         align: 'center',
-        renderCell: ({ row }) => (
-          <LinkStyled href={`/apps/student/edit/${row?.id}?classroom=${currentClassroomId}`} passHref>
-            <Button color='warning' variant='contained' startIcon={<AccountEditOutline fontSize='small' />}>
-              แก้ไข
-            </Button>
-          </LinkStyled>
-        ),
-      },
-      {
-        flex: 0.15,
-        minWidth: 120,
-        field: 'delete',
-        headerName: 'ลบข้อมูล',
-        editable: false,
-        sortable: false,
-        hideSortIcons: true,
-        filterable: false,
-        align: 'center',
-        renderCell: ({ row }) => (
-          <Button
-            color='error'
-            variant='contained'
-            startIcon={<RiUserUnfollowLine fontSize='small' />}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDeleteClick(row);
-            }}
-          >
-            ลบ
-          </Button>
-        ),
-      },
-      {
-        flex: 0.15,
-        minWidth: 120,
-        field: 'details',
-        headerName: 'ดูรายละเอียด',
-        sortable: false,
-        align: 'center',
-        renderCell: () => (
-          <Button disabled color='primary' variant='contained' startIcon={<RiUserSearchLine fontSize='small' />}>
-            ดู
-          </Button>
-        ),
+        headerAlign: 'center',
+        renderCell: ({ row }) => {
+          const isGraduated = row.studentStatus === 'graduated' || row.isGraduation === true;
+
+          const getActionIconSx = (color: 'info' | 'warning' | 'error' | 'success' | 'primary') => ({
+            width: 32,
+            height: 32,
+            borderRadius: 1.5,
+            border: (theme: Theme) => `1px solid ${alpha(theme.palette[color].main, 0.24)}`,
+            backgroundColor: (theme: Theme) => alpha(theme.palette[color].main, 0.12),
+            color: `${color}.dark`,
+            transition: 'all 160ms ease',
+            '&:hover': {
+              backgroundColor: (theme: Theme) => alpha(theme.palette[color].main, 0.2),
+            },
+            '&.Mui-disabled': {
+              borderColor: (theme: Theme) => alpha(theme.palette.action.disabled, 0.28),
+              backgroundColor: (theme: Theme) => alpha(theme.palette.action.disabledBackground, 0.46),
+              color: 'text.disabled',
+            },
+          });
+
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.75, width: '100%' }}>
+              <Tooltip title='ดูรายละเอียด'>
+                <IconButton href={`/apps/student/view/${row?.id}`} sx={getActionIconSx('info')}>
+                  <RiUserSearchLine fontSize='1rem' />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title='แก้ไข'>
+                <IconButton
+                  href={`/apps/student/edit/${row?.id}?classroom=${currentClassroomId}`}
+                  sx={getActionIconSx('warning')}
+                >
+                  <AccountEditOutline fontSize='small' />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title='เลื่อนชั้น'>
+                <IconButton
+                  disabled={isGraduated}
+                  sx={getActionIconSx('primary')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleIndividualPromoteClick(row);
+                  }}
+                >
+                  <RiArrowUpLine fontSize='1rem' />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={isGraduated ? 'จบแล้ว' : 'จบการศึกษา'}>
+                <IconButton
+                  disabled={isGraduated}
+                  sx={getActionIconSx('success')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleGraduationClick(row);
+                  }}
+                >
+                  <RiGraduationCapLine fontSize='1rem' />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title='ลบข้อมูล'>
+                <IconButton
+                  sx={getActionIconSx('error')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeleteClick(row);
+                  }}
+                >
+                  <RiUserUnfollowLine fontSize='1rem' />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          );
+        },
       },
     ],
-    [currentClassroomId, handleDeleteClick],
+    [currentClassroomId, handleDeleteClick, handleGraduationClick, handleIndividualPromoteClick],
   );
 
   return (
@@ -491,12 +517,17 @@ const StudentListPage = () => {
               onImportStudents={handleImportStudents}
               onDownloadTemplate={handleDownloadTemplate}
               onExportStudents={handleExportStudents}
+              onBulkGraduate={isAdmin ? handleBulkGraduationClick : undefined}
+              onBulkPromote={isAdmin ? handlePromoteClick : undefined}
+              onStatusChange={handleStatusChange}
+              studentStatus={searchValue.studentStatus}
               studentId={searchValue.studentId}
               students={students}
               canImportStudents={isAdmin}
               isImportingStudents={isImportingStudents}
               isDownloadingTemplate={isDownloadingTemplate}
               isExportingStudents={isExportingStudents}
+              isPromoting={isPromoting}
             />
             <StyledDataGrid
               rows={students}
@@ -521,8 +552,55 @@ const StudentListPage = () => {
         <StudentDeleteDialog
           open={openDeletedConfirm}
           student={deletedStudent}
+          isDeleting={isDeleting}
+          onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
-          onCancel={handleDeleteCancel}
+        />
+      )}
+      {openGraduationConfirm && (
+        <StudentGraduationDialog
+          open={openGraduationConfirm}
+          student={graduationStudent}
+          isGraduating={isGraduating}
+          onClose={handleGraduationCancel}
+          onConfirm={handleGraduationConfirm}
+        />
+      )}
+      {openBulkGraduationConfirm && (
+        <StudentBulkGraduationDialog
+          open={openBulkGraduationConfirm}
+          classroomName={initClassroom?.name ?? ''}
+          studentCount={students.length}
+          isGraduating={isGraduatingClassroom}
+          onClose={handleBulkGraduationCancel}
+          onConfirm={handleBulkGraduationConfirm}
+        />
+      )}
+      {openPromoteConfirm && (
+        <ClassroomPromotionDialog
+          open={openPromoteConfirm}
+          classrooms={classrooms}
+          promoteSource={promoteSource}
+          promoteTarget={promoteTarget}
+          promotePreview={promotePreview}
+          isLoadingPreview={isLoadingPromotePreview}
+          isPromoting={isPromoting}
+          onSourceChange={handlePromoteSourceChange}
+          onTargetChange={handlePromoteTargetChange}
+          onConfirm={handlePromoteConfirm}
+          onCancel={handlePromoteCancel}
+        />
+      )}
+      {openIndividualPromoteConfirm && (
+        <StudentIndividualPromotionDialog
+          open={openIndividualPromoteConfirm}
+          student={promoteStudent}
+          classrooms={classrooms}
+          targetClassroom={promoteStudentTarget}
+          isPromoting={isPromoting}
+          onTargetChange={handleIndividualPromoteTargetChange}
+          onConfirm={handleIndividualPromoteConfirm}
+          onCancel={handleIndividualPromoteCancel}
         />
       )}
       <StudentImportResultDialog

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -1,5 +1,5 @@
 import Icon from '@/@core/components/icon';
-import { Autocomplete, Box, FormControl, IconButton, InputAdornment, Tooltip, Typography } from '@mui/material';
+import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, Select, Tooltip, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { alpha, styled } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
@@ -22,12 +22,17 @@ interface TableHeaderProps {
   onImportStudents: (file: File | null) => Promise<void>;
   onDownloadTemplate: () => Promise<void>;
   onExportStudents: () => Promise<void>;
+  onBulkGraduate?: () => void;
+  onBulkPromote?: () => void;
+  onStatusChange: (status: string) => void;
+  studentStatus: string;
   studentId: string;
   students: any;
   canImportStudents: boolean;
   isImportingStudents: boolean;
   isDownloadingTemplate: boolean;
   isExportingStudents: boolean;
+  isPromoting?: boolean;
 }
 
 const PANEL_RADIUS = 16;
@@ -156,12 +161,17 @@ const TableHeader = memo((props: TableHeaderProps) => {
     onImportStudents,
     onDownloadTemplate,
     onExportStudents,
+    onBulkGraduate,
+    onBulkPromote,
+    onStatusChange,
+    studentStatus,
     studentId,
     students = [],
     canImportStudents,
     isImportingStudents,
     isDownloadingTemplate,
     isExportingStudents,
+    isPromoting,
   } = props;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -329,6 +339,36 @@ const TableHeader = memo((props: TableHeaderProps) => {
                 </>
               )}
 
+              {onBulkGraduate && (
+                <>
+                  <Tooltip title='จบการศึกษาทั้งห้อง'>
+                    <ToolButtonSlot component='span'>
+                      <ToolButton id='bulk-graduate-button' onClick={onBulkGraduate}>
+                        <Icon icon='tabler:school' />
+                      </ToolButton>
+                    </ToolButtonSlot>
+                  </Tooltip>
+                  <ToolDivider />
+                </>
+              )}
+
+              {onBulkPromote && (
+                <>
+                  <Tooltip title={isPromoting ? 'กำลังเลื่อนชั้น...' : 'เลื่อนชั้นนักเรียน'}>
+                    <ToolButtonSlot component='span'>
+                      <ToolButton
+                        id='bulk-promote-button'
+                        onClick={onBulkPromote}
+                        disabled={isPromoting}
+                      >
+                        <Icon icon='tabler:arrow-up' />
+                      </ToolButton>
+                    </ToolButtonSlot>
+                  </Tooltip>
+                  <ToolDivider />
+                </>
+              )}
+
               <Tooltip title='เพิ่มนักเรียน'>
                 <LinkStyled href='/apps/student/add' passHref>
                   <ToolButtonSlot component='span'>
@@ -342,7 +382,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
           </Box>
 
           <Grid container spacing={{ xs: 1.5, sm: 2 }}>
-            <FilterGrid id='student-list-student-id-filter' size={{ xs: 12, md: 4 }}>
+            <FilterGrid id='student-list-student-id-filter' size={{ xs: 12, md: 3 }}>
               <FormControl id='student-id-form-control' fullWidth>
                 <TextField
                   id='studentId'
@@ -373,7 +413,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
               </FormControl>
             </FilterGrid>
 
-            <FilterGrid id='student-list-student-name-filter' size={{ xs: 12, md: 4 }}>
+            <FilterGrid id='student-list-student-name-filter' size={{ xs: 12, md: 3 }}>
               <FormControl id='student-name-form-control' fullWidth>
                 <Autocomplete
                   id='studentName'
@@ -420,14 +460,20 @@ const TableHeader = memo((props: TableHeaderProps) => {
               </FormControl>
             </FilterGrid>
 
-            <FilterGrid id='student-list-classroom-filter' size={{ xs: 12, md: 4 }}>
+            <FilterGrid id='student-list-classroom-filter' size={{ xs: 12, md: 3 }}>
               <FormControl id='classroom-form-control' fullWidth>
                 <Autocomplete
                   id='classroom'
                   fullWidth
                   disablePortal={false}
                   value={defaultClassroom || null}
-                  options={Array.isArray(classrooms) ? classrooms : []}
+                  options={
+                    Array.isArray(classrooms)
+                      ? [...classrooms].sort((a: any, b: any) =>
+                          (a.department?.name ?? '').localeCompare(b.department?.name ?? '', 'th'),
+                        )
+                      : []
+                  }
                   loading={loading}
                   onChange={(_, newValue: any) => onHandleChange(_, newValue)}
                   getOptionLabel={(option: any) => option?.name ?? ''}
@@ -456,6 +502,33 @@ const TableHeader = memo((props: TableHeaderProps) => {
                   )}
                   noOptionsText='ไม่พบข้อมูล'
                 />
+              </FormControl>
+            </FilterGrid>
+
+            <FilterGrid id='student-list-status-filter' size={{ xs: 12, md: 3 }}>
+              <FormControl fullWidth sx={controlTextFieldSx}>
+                <InputLabel id='student-status-label' shrink>
+                  สถานะนักเรียน
+                </InputLabel>
+                <Select
+                  id='student-status-select'
+                  labelId='student-status-label'
+                  label='สถานะนักเรียน'
+                  value={studentStatus}
+                  onChange={(e) => onStatusChange(e.target.value)}
+                  displayEmpty
+                  notched
+                  sx={{
+                    '& .MuiSelect-select': {
+                      fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
+                    },
+                  }}
+                >
+                  <MenuItem value=''>ทุกสถานะ</MenuItem>
+                  <MenuItem value='normal'>เรียนอยู่</MenuItem>
+                  <MenuItem value='graduated'>จบการศึกษา</MenuItem>
+                  <MenuItem value='dropout'>ไม่เรียนแล้ว</MenuItem>
+                </Select>
               </FormControl>
             </FilterGrid>
           </Grid>

--- a/frontend/src/views/apps/student/view/StudentViewPage.tsx
+++ b/frontend/src/views/apps/student/view/StudentViewPage.tsx
@@ -1,29 +1,40 @@
 'use client';
 
-import { useState, useEffect, SyntheticEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
+import Skeleton from '@mui/material/Skeleton';
+import Tab from '@mui/material/Tab';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
-import Tab from '@mui/material/Tab';
-import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import Avatar from '@mui/material/Avatar';
-import { styled, useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import Icon from '@/@core/components/icon';
 
-interface StudentViewPageProps {
-  id: string;
-}
+import Icon from '@/@core/components/icon';
+import CardAward from './CardAward';
+import TimelineBadness from './TimelineBadness';
+import TimelineGoodness from './TimelineGoodness';
+import UserViewLeft from './UserViewLeft';
+
+import { useStudentGoodnessRecords, useDeleteGoodnessRecord } from '@/hooks/queries/useGoodness';
+import { useStudentBadnessRecords, useDeleteBadnessRecord } from '@/hooks/queries/useBadness';
+import { useStudent, useStudentTrophyOverview, useStudentClassroomTeachers } from '@/hooks/queries/useStudents';
+import { useAuth } from '@/hooks/useAuth';
+import useImageQuery from '@/hooks/useImageQuery';
+
+import type { StudentData } from '@/types/apps/studentTypes';
+
+// ── Styled tab list ─────────────────────────────────────────────────────────────
 
 const MuiTabList = styled(TabList)(({ theme }) => ({
-  '& .MuiTabs-indicator': {
-    display: 'none',
-  },
+  '& .MuiTabs-indicator': { display: 'none' },
   '& .Mui-selected': {
     backgroundColor: theme.palette.primary.main,
     color: `${theme.palette.common.white} !important`,
@@ -34,177 +45,267 @@ const MuiTabList = styled(TabList)(({ theme }) => ({
     paddingTop: theme.spacing(2.5),
     paddingBottom: theme.spacing(2.5),
     borderRadius: theme.shape.borderRadius,
-    [theme.breakpoints.up('sm')]: {
-      minWidth: 130,
-    },
+    [theme.breakpoints.up('sm')]: { minWidth: 130 },
   },
 }));
 
-const StudentViewPage = ({ id }: StudentViewPageProps) => {
-  const [activeTab, setActiveTab] = useState<string>('overview');
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+// ── Helpers ─────────────────────────────────────────────────────────────────────
 
-  const router = useRouter();
-  const theme = useTheme();
-  const hideText = useMediaQuery(theme.breakpoints.down('sm'));
+const statusMap: Record<string, { label: string; color: 'success' | 'error' | 'info' | 'default' }> = {
+  active: { label: 'กำลังศึกษา', color: 'success' },
+  inactive: { label: 'ไม่ได้ศึกษา', color: 'error' },
+  graduated: { label: 'สำเร็จการศึกษา', color: 'info' },
+};
 
-  const handleChange = (event: SyntheticEvent, value: string) => {
-    setActiveTab(value);
-  };
+const EmptyState = ({ icon, label }: { icon: string; label: string }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      py: 14,
+      gap: 2,
+      color: 'text.disabled',
+    }}
+  >
+    <Icon icon={icon} fontSize={48} />
+    <Typography variant='body2'>{label}</Typography>
+  </Box>
+);
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
+const DetailRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <Box sx={{ display: 'flex', mb: 3, gap: 2, alignItems: 'center' }}>
+    <Box sx={{ fontWeight: 600, minWidth: 148, color: 'text.secondary', flexShrink: 0, fontSize: '0.875rem' }}>
+      {label}
+    </Box>
+    <Box sx={{ color: 'text.primary', fontSize: '0.875rem', display: 'flex', alignItems: 'center' }}>
+      {value ?? '-'}
+    </Box>
+  </Box>
+);
 
-  const mockStudentData = {
-    id,
-    studentId: id,
-    title: 'นาย',
-    firstName: 'ทดสอบ',
-    lastName: 'ระบบ',
-    classroom: 'ปวช.1/1',
-    email: 'test@nktc.ac.th',
-    phone: '08-xxxx-xxxx',
-    status: 'active',
+// ── Student detail card ─────────────────────────────────────────────────────────
+
+const StudentDetailCard = ({ student }: { student: StudentData | undefined }) => {
+  if (!student) {
+    return (
+      <Card>
+        <CardContent>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} variant='text' height={28} sx={{ mb: 1.5 }} />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { user, classroom, program, department, level, studentId, status } = student;
+  const account = user.account;
+
+  const address = [account.addressLine1, account.subdistrict, account.district, account.province, account.postcode]
+    .filter(Boolean)
+    .join(' ');
+
+  const statusInfo = statusMap[status] ?? { label: status, color: 'default' as const };
+
+  const formatDate = (date: string | null) => {
+    if (!date) return null;
+    return new Date(date).toLocaleDateString('th-TH', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
   };
 
   return (
+    <Card>
+      <CardContent sx={{ pt: 5, pb: '20px !important' }}>
+        <Typography variant='h6' sx={{ mb: 4 }}>
+          ข้อมูลส่วนตัว
+        </Typography>
+        <Divider sx={{ mb: 4 }} />
+
+        <DetailRow label='รหัสนักเรียน' value={studentId} />
+        <DetailRow
+          label='สถานะ'
+          value={<Chip size='small' label={statusInfo.label} color={statusInfo.color} />}
+        />
+        <DetailRow label='วันเกิด' value={formatDate(account.birthDate)} />
+        <DetailRow label='เลขบัตรประชาชน' value={account.idCard} />
+        <DetailRow label='เบอร์โทรศัพท์' value={account.phone} />
+        <DetailRow label='ที่อยู่' value={address || null} />
+
+        {(program || department || level || classroom) && (
+          <>
+            <Divider sx={{ my: 4 }} />
+            <Typography variant='h6' sx={{ mb: 4 }}>
+              ข้อมูลการศึกษา
+            </Typography>
+            {level && <DetailRow label='ระดับชั้น' value={level.levelFullName} />}
+            {classroom && <DetailRow label='ห้องเรียน' value={classroom.name} />}
+            {program && <DetailRow label='สาขาวิชา' value={program.name} />}
+            {department && <DetailRow label='แผนก' value={department.name} />}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+// ── Page ────────────────────────────────────────────────────────────────────────
+
+interface StudentViewPageProps {
+  id: string;
+}
+
+const StudentViewPage = ({ id }: StudentViewPageProps) => {
+  const [activeTab, setActiveTab] = useState('overview');
+  const { user: authUser } = useAuth() as any;
+
+  const { data: student } = useStudent(id);
+  const { data: trophyOverview } = useStudentTrophyOverview(id);
+  const { data: goodnessData } = useStudentGoodnessRecords(id, 0, 30);
+  const { data: badnessData } = useStudentBadnessRecords(id, 0, 30);
+  const { data: teacherClassroom = [] } = useStudentClassroomTeachers(student?.classroom?.classroomId ?? '');
+  const { mutate: deleteGoodness } = useDeleteGoodnessRecord();
+  const { mutate: deleteBadness } = useDeleteBadnessRecord();
+
+  const avatarUrl = student?.user?.account?.avatar ?? '';
+  const { image, isLoading: imageLoading } = useImageQuery(avatarUrl);
+
+  const fullName = student
+    ? `${student.user.account.title}${student.user.account.firstName} ${student.user.account.lastName}`
+    : '';
+
+  const classroomName = student?.classroom
+    ? `${student.classroom.level?.levelName ?? ''} ${student.classroom.name ?? ''}`.trim()
+    : '-';
+
+  const goodnessRecords: any[] = Array.isArray(goodnessData)
+    ? goodnessData
+    : (goodnessData as any)?.data ?? [];
+
+  const badnessRecords: any[] = Array.isArray(badnessData)
+    ? badnessData
+    : (badnessData as any)?.data ?? [];
+
+  const trophy = trophyOverview as any;
+  const isEligibleForAward =
+    (trophy?.totalTrophy ?? 0) > 0 && (trophy?.goodScore ?? 0) > (trophy?.badScore ?? 0);
+
+  return (
     <Grid container spacing={6}>
+      {/* Back button */}
       <Grid size={12}>
-        <Card>
-          <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 4 }}>
-              <Avatar
-                sx={{ width: 120, height: 120, mr: 4 }}
-                src='/images/avatars/1.png'
-                alt={`${mockStudentData.firstName} ${mockStudentData.lastName}`}
-              />
-              <Box>
-                <Typography variant='h4' sx={{ mb: 2 }}>
-                  {mockStudentData.title}
-                  {mockStudentData.firstName} {mockStudentData.lastName}
-                </Typography>
-                <Typography variant='body1' sx={{ mb: 1 }}>
-                  รหัสนักเรียน: {mockStudentData.studentId}
-                </Typography>
-                <Typography variant='body1' sx={{ mb: 1 }}>
-                  ชั้นเรียน: {mockStudentData.classroom}
-                </Typography>
-                <Typography variant='body1' sx={{ mb: 1 }}>
-                  อีเมล: {mockStudentData.email}
-                </Typography>
-                <Typography variant='body1'>เบอร์โทร: {mockStudentData.phone}</Typography>
-              </Box>
-            </Box>
-          </CardContent>
-        </Card>
+        <Button
+          component={Link}
+          href='/apps/student/list'
+          variant='text'
+          startIcon={<Icon icon='mdi:arrow-left' fontSize={18} />}
+          sx={{ color: 'text.secondary', fontWeight: 500 }}
+        >
+          ย้อนกลับ
+        </Button>
       </Grid>
-      <Grid size={12}>
+
+      {/* Sidebar */}
+      <Grid size={{ xs: 12, md: 4 }}>
+        <UserViewLeft
+          user={student?.user}
+          trophyOverview={trophyOverview}
+          teacherClassroom={teacherClassroom}
+          isLoading={imageLoading}
+          image={image}
+          fullName={fullName}
+          classroomName={classroomName}
+        />
+      </Grid>
+
+      {/* Main content */}
+      <Grid size={{ xs: 12, md: 8 }}>
         <TabContext value={activeTab}>
-          <Grid container spacing={6}>
-            <Grid size={12}>
-              <MuiTabList
-                variant='scrollable'
-                scrollButtons='auto'
-                onChange={handleChange}
-                aria-label='student profile tabs'
-              >
-                <Tab
-                  value='overview'
-                  label={
-                    <Box sx={{ display: 'flex', alignItems: 'center', ...(!hideText && { '& svg': { mr: 2 } }) }}>
-                      <Icon fontSize={20} icon='mdi:account-outline' />
-                      {!hideText && 'ภาพรวม'}
-                    </Box>
-                  }
-                />
-                <Tab
-                  value='goodness'
-                  label={
-                    <Box sx={{ display: 'flex', alignItems: 'center', ...(!hideText && { '& svg': { mr: 2 } }) }}>
-                      <Icon fontSize={20} icon='mdi:star-outline' />
-                      {!hideText && 'ความดี'}
-                    </Box>
-                  }
-                />
-                <Tab
-                  value='badness'
-                  label={
-                    <Box sx={{ display: 'flex', alignItems: 'center', ...(!hideText && { '& svg': { mr: 2 } }) }}>
-                      <Icon fontSize={20} icon='mdi:alert-outline' />
-                      {!hideText && 'ความประพฤติ'}
-                    </Box>
-                  }
-                />
-              </MuiTabList>
-            </Grid>
-            <Grid size={12}>
-              <TabPanel sx={{ p: 0 }} value='overview'>
-                <Card>
-                  <CardContent>
-                    <Typography variant='h6' sx={{ mb: 3 }}>
-                      ข้อมูลส่วนตัว
-                    </Typography>
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <Typography variant='body2' sx={{ fontWeight: 600 }}>
-                          ชื่อ-นามสกุล:
-                        </Typography>
-                        <Typography variant='body2'>
-                          {mockStudentData.title}
-                          {mockStudentData.firstName} {mockStudentData.lastName}
-                        </Typography>
-                      </Box>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <Typography variant='body2' sx={{ fontWeight: 600 }}>
-                          รหัสนักเรียน:
-                        </Typography>
-                        <Typography variant='body2'>{mockStudentData.studentId}</Typography>
-                      </Box>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <Typography variant='body2' sx={{ fontWeight: 600 }}>
-                          ชั้นเรียน:
-                        </Typography>
-                        <Typography variant='body2'>{mockStudentData.classroom}</Typography>
-                      </Box>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <Typography variant='body2' sx={{ fontWeight: 600 }}>
-                          สถานะ:
-                        </Typography>
-                        <Typography variant='body2' sx={{ color: 'success.main' }}>
-                          กำลังศึกษา
-                        </Typography>
-                      </Box>
-                    </Box>
-                  </CardContent>
-                </Card>
-              </TabPanel>
-              <TabPanel sx={{ p: 0 }} value='goodness'>
-                <Card>
-                  <CardContent>
-                    <Typography variant='h6' sx={{ mb: 3 }}>
-                      ประวัติความดี
-                    </Typography>
-                    <Typography variant='body2' color='text.secondary'>
-                      ไม่มีข้อมูลประวัติความดี
-                    </Typography>
-                  </CardContent>
-                </Card>
-              </TabPanel>
-              <TabPanel sx={{ p: 0 }} value='badness'>
-                <Card>
-                  <CardContent>
-                    <Typography variant='h6' sx={{ mb: 3 }}>
-                      ประวัติความประพฤติ
-                    </Typography>
-                    <Typography variant='body2' color='text.secondary'>
-                      ไม่มีข้อมูลประวัติความประพฤติ
-                    </Typography>
-                  </CardContent>
-                </Card>
-              </TabPanel>
-            </Grid>
-          </Grid>
+          <MuiTabList
+            variant='scrollable'
+            scrollButtons='auto'
+            onChange={(_, v: string) => setActiveTab(v)}
+            aria-label='student profile tabs'
+          >
+            <Tab
+              value='overview'
+              label={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Icon fontSize={18} icon='mdi:account-outline' />
+                  ภาพรวม
+                </Box>
+              }
+            />
+            <Tab
+              value='goodness'
+              label={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Icon fontSize={18} icon='mdi:star-outline' />
+                  ความดี
+                  {goodnessRecords.length > 0 && (
+                    <Chip
+                      size='small'
+                      label={goodnessRecords.length}
+                      color='success'
+                      sx={{ height: 18, fontSize: '0.65rem', ml: 0.5 }}
+                    />
+                  )}
+                </Box>
+              }
+            />
+            <Tab
+              value='badness'
+              label={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Icon fontSize={18} icon='mdi:alert-outline' />
+                  ความประพฤติ
+                  {badnessRecords.length > 0 && (
+                    <Chip
+                      size='small'
+                      label={badnessRecords.length}
+                      color='error'
+                      sx={{ height: 18, fontSize: '0.65rem', ml: 0.5 }}
+                    />
+                  )}
+                </Box>
+              }
+            />
+          </MuiTabList>
+
+          <Box sx={{ mt: 6 }}>
+            <TabPanel sx={{ p: 0 }} value='overview'>
+              <Grid container spacing={4}>
+                {isEligibleForAward && (
+                  <Grid size={12}>
+                    <CardAward trophyOverview={trophyOverview} fullName={fullName} />
+                  </Grid>
+                )}
+                <Grid size={12}>
+                  <StudentDetailCard student={student} />
+                </Grid>
+              </Grid>
+            </TabPanel>
+
+            <TabPanel sx={{ p: 0 }} value='goodness'>
+              {goodnessRecords.length === 0 ? (
+                <EmptyState icon='mdi:star-outline' label='ยังไม่มีบันทึกความดี' />
+              ) : (
+                <TimelineGoodness info={goodnessRecords} user={authUser} onDeleted={deleteGoodness} />
+              )}
+            </TabPanel>
+
+            <TabPanel sx={{ p: 0 }} value='badness'>
+              {badnessRecords.length === 0 ? (
+                <EmptyState icon='mdi:alert-outline' label='ยังไม่มีบันทึกความประพฤติ' />
+              ) : (
+                <TimelineBadness info={badnessRecords} user={authUser} onDeleted={deleteBadness} />
+              )}
+            </TabPanel>
+          </Box>
         </TabContext>
       </Grid>
     </Grid>

--- a/frontend/src/views/apps/student/view/TimelineBadness.tsx
+++ b/frontend/src/views/apps/student/view/TimelineBadness.tsx
@@ -48,7 +48,6 @@ const TimelineBadness = ({ info, user, onDeleted }: Props) => {
         <Card>
           <CardHeader title='รายละเอียคความประพฤติ' />
           <CardContent>
-            {/* @ts-expect-error - React 19 type compatibility issue with MUI Lab */}
             <Timeline
               sx={{
                 margin: 0,

--- a/frontend/src/views/apps/student/view/TimelineGoodness.tsx
+++ b/frontend/src/views/apps/student/view/TimelineGoodness.tsx
@@ -4,17 +4,16 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
+import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';
 import { TimelineConnector, TimelineContent, TimelineDot, TimelineItem, TimelineSeparator } from '@mui/lab';
 
-import CircularProgress from '@mui/material/CircularProgress';
 import { calculateTimeAgo } from '@/utils/datetime';
 import useImageQuery from '@/hooks/useImageQuery';
 import IconifyIcon from '@/@core/components/icon';
-import { getStudentName } from '@/utils/student';
 
 interface Props {
   info: any[];
@@ -27,162 +26,131 @@ interface ImageDisplayProps {
 }
 
 const ImageDisplay = ({ image }: ImageDisplayProps) => {
-  const { isLoading, image: badnessImage } = useImageQuery(image);
+  const { isLoading, image: goodnessImage } = useImageQuery(image);
 
   return isLoading ? (
-    <CircularProgress />
-  ) : badnessImage ? (
+    <CircularProgress size={24} />
+  ) : goodnessImage ? (
     <div
-      role="button"
+      role='button'
       tabIndex={0}
-      style={{
-        cursor: 'pointer',
-      }}
-      onClick={() => {
-        window.open(badnessImage, '_blank');
-      }}
+      style={{ cursor: 'pointer' }}
+      onClick={() => window.open(goodnessImage, '_blank')}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') window.open(badnessImage, '_blank');
+        if (e.key === 'Enter' || e.key === ' ') window.open(goodnessImage, '_blank');
       }}
     >
-      <Avatar alt='บันทึกความดี' src={badnessImage as any} sx={{ width: '5.5rem', height: '5.5rem' }} />
+      <Avatar alt='บันทึกความดี' src={goodnessImage as any} sx={{ width: '5.5rem', height: '5.5rem' }} />
     </div>
   ) : (
-    <Typography variant='subtitle2' sx={{ fontWeight: 400, color: 'text.primary', textDecoration: 'none' }}>
+    <Typography variant='subtitle2' sx={{ fontWeight: 400, color: 'text.primary' }}>
       ไม่มีรูปภาพ
     </Typography>
   );
 };
 
 const TimelineGoodness = ({ info, user, onDeleted }: Props) => {
-  // Handle both single object and array formats
-  const goodnessRecord = Array.isArray(info) ? info[0] : info;
-  const isEmpty = !goodnessRecord;
-
-  console.log('TimelineGoodness rendered with info:', info);
-  console.log('TimelineGoodness - isEmpty:', isEmpty);
-  console.log('TimelineGoodness - goodnessRecord:', goodnessRecord);
-
-  // Get student name from the goodness record
-  const getStudentDisplayName = () => {
-    console.log('getStudentDisplayName - goodnessRecord:', goodnessRecord);
-    console.log('getStudentDisplayName - goodnessRecord.student:', goodnessRecord?.student);
-
-    if (goodnessRecord?.student) {
-      const studentData = goodnessRecord.student;
-      console.log('getStudentDisplayName - studentData:', studentData);
-      console.log('getStudentDisplayName - studentData.user:', studentData.user);
-      console.log('getStudentDisplayName - studentData.user?.account:', studentData.user?.account);
-
-      const name = getStudentName(studentData);
-      console.log('getStudentDisplayName - calculated name:', name);
-      return name;
-    }
-    return 'ไม่ระบุชื่อ';
-  };
+  if (!info || info.length === 0) {
+    return (
+      <Grid container spacing={6}>
+        <Grid size={12}>
+          <Card>
+            <CardContent>
+              <Typography variant='body2' sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
+                ไม่พบข้อมูลความดี
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    );
+  }
 
   return (
     <Grid container spacing={6}>
       <Grid size={12}>
         <Card>
           <CardHeader
-            title={`รายละเอียดความดี - ${getStudentDisplayName()}`}
-            slotProps={{
-              title: { variant: 'h6' },
-            }}
+            title='บันทึกความดี'
+            slotProps={{ title: { variant: 'h6' } }}
           />
           <CardContent>
-            {isEmpty ? (
-              <Typography variant='body2' sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
-                ไม่พบข้อมูลความดี
-              </Typography>
-            ) : (
-              <>
-                <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
-                  รายละเอียดความดี
-                </Typography>
-                {/* @ts-expect-error - React 19 type compatibility issue with MUI Lab */}
-                <Timeline
-                  sx={{
-                    margin: 0,
-                    padding: 0,
-                    marginLeft: 0.75,
-                    paddingBottom: 3,
-                    '& .MuiTimelineItem-root': {
-                      '&:before': {
-                        display: 'none',
-                      },
-                      '&:last-child': {
-                        minHeight: 60,
-                      },
-                    },
-                  }}
-                >
-                  <TimelineItem key={goodnessRecord?.id || 'timeline-item'}>
-                    <TimelineSeparator>
-                      <TimelineDot color='success' />
-                      <TimelineConnector />
-                    </TimelineSeparator>
-                    <TimelineContent>
-                      <Box
-                        sx={{
-                          mb: 2,
-                          display: 'flex',
-                          flexWrap: 'wrap',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                        }}
-                      >
-                        <Typography variant='body2' sx={{ mr: 2, fontWeight: 600, color: 'text.primary' }}>
-                          {goodnessRecord?.goodnessDetail}
-                        </Typography>
-                        <Typography variant='caption' suppressHydrationWarning>
-                          {goodnessRecord?.goodDate ? calculateTimeAgo(new Date(goodnessRecord?.goodDate)) : ''}
-                        </Typography>
-                      </Box>
-                      <Typography variant='body2' suppressHydrationWarning>
-                        {`ความดี ${goodnessRecord?.goodnessScore} คะแนน `}
-                        {goodnessRecord?.goodDate
-                          ? `ณ ${new Date(goodnessRecord?.goodDate).toLocaleTimeString('th-TH', {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            })}น.`
-                          : ''}
+            <Timeline
+              sx={{
+                margin: 0,
+                padding: 0,
+                marginLeft: 0.75,
+                paddingBottom: 3,
+                '& .MuiTimelineItem-root': {
+                  '&:before': { display: 'none' },
+                  '&:last-child': { minHeight: 60 },
+                },
+              }}
+            >
+              {info.map((record: any) => (
+                <TimelineItem key={record?.id}>
+                  <TimelineSeparator>
+                    <TimelineDot color='success' />
+                    <TimelineConnector />
+                  </TimelineSeparator>
+                  <TimelineContent>
+                    <Box
+                      sx={{
+                        mb: 2,
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Typography variant='body2' sx={{ mr: 2, fontWeight: 600, color: 'text.primary' }}>
+                        {record?.goodnessDetail}
                       </Typography>
-                      <Box
-                        sx={{
-                          mt: 2,
-                          display: 'flex',
-                          flexDirection: 'row',
-                          alignItems: 'center',
-                          alignContent: 'space-between',
-                          justifyContent: 'space-between',
-                        }}
-                      >
-                        <Box sx={{ width: 200, height: 'auto' }}>
-                          <ImageDisplay image={goodnessRecord?.image} />
-                        </Box>
-                        {user?.role === 'Admin' && (
-                          <Box sx={{ ml: 2 }}>
-                            <Tooltip title='ลบการบันทึกความดี'>
-                              <Button
-                                size='small'
-                                variant='outlined'
-                                color='error'
-                                startIcon={<IconifyIcon icon={'fluent:delete-off-24-regular'} />}
-                                onClick={() => onDeleted?.(goodnessRecord?.id)}
-                              >
-                                ลบบันทึก
-                              </Button>
-                            </Tooltip>
-                          </Box>
-                        )}
+                      <Typography variant='caption' suppressHydrationWarning>
+                        {record?.goodDate ? calculateTimeAgo(new Date(record?.goodDate)) : ''}
+                      </Typography>
+                    </Box>
+                    <Typography variant='body2' suppressHydrationWarning>
+                      {`ความดี ${record?.goodnessScore} คะแนน `}
+                      {record?.goodDate
+                        ? `ณ ${new Date(record?.goodDate).toLocaleTimeString('th-TH', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}น.`
+                        : ''}
+                    </Typography>
+                    <Box
+                      sx={{
+                        mt: 2,
+                        display: 'flex',
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box sx={{ width: 200, height: 'auto' }}>
+                        <ImageDisplay image={record?.image} />
                       </Box>
-                    </TimelineContent>
-                  </TimelineItem>
+                      {user?.role === 'Admin' && (
+                        <Box sx={{ ml: 2 }}>
+                          <Tooltip title='ลบการบันทึกความดี'>
+                            <Button
+                              size='small'
+                              variant='outlined'
+                              color='error'
+                              startIcon={<IconifyIcon icon='fluent:delete-off-24-regular' />}
+                              onClick={() => onDeleted?.(record?.id)}
+                            >
+                              ลบบันทึก
+                            </Button>
+                          </Tooltip>
+                        </Box>
+                      )}
+                    </Box>
+                  </TimelineContent>
+                </TimelineItem>
+              ))}
             </Timeline>
-              </>
-            )}
           </CardContent>
         </Card>
       </Grid>


### PR DESCRIPTION
## Summary

- **Student promotion** — ClassroomPromotionDialog promotes all students between classrooms with conflict detection and preview; StudentIndividualPromotionDialog for per-student promotion
- **Student graduation** — StudentGraduationDialog (per-student) and StudentBulkGraduationDialog (whole classroom); backend `graduate-classroom` endpoint
- **Student view redesign** — real API data replacing mock data, 2-column layout, tabbed panels (overview / goodness / badness), back button, trophy scores, tab count badges
- **Shared dialog system** — `ConfirmDialog`, `GenericDeleteDialog`, `GenericGraduationDialog` extracted to `@core/components/dialogs`; all delete dialogs refactored to use shared components
- **Bug fixes** — blank student list after back navigation, trophy scores showing 0, hydration error in detail card, cancel/save in edit page losing classroom param

## Test plan

- [ ] Open `/apps/settings/classroom` — promote classroom action opens dialog, shows preview count, promotes students
- [ ] Open `/apps/student/list` — individual promote button per student row works
- [ ] Open `/apps/student/view/[id]` — overview tab shows detail card and trophy info; goodness/badness tabs show records with counts
- [ ] Back button on view page navigates to `/apps/student/list` without blank screen
- [ ] Open `/apps/student/edit/[id]?classroom=[id]` — cancel and save both navigate back to list with classroom param preserved
- [ ] Delete dialogs for classroom, department, program, student, teacher all open and close correctly
- [ ] Trophy scores display non-zero values when student has goodness/badness records