### PR TITLE
feat: add bulk delete students feature and UI improvements

### DIFF
--- a/backend-elysia/src/modules/students/index.ts
+++ b/backend-elysia/src/modules/students/index.ts
@@ -152,6 +152,19 @@ export const students = new Elysia({ prefix: "/students" })
 					detail: { summary: "Graduate all students in a classroom" },
 				},
 			)
+			.delete(
+				"/classroom/:id",
+				async ({ params: { id }, user, set }) => {
+					if ((user as any)?.roles !== "Admin") {
+						set.status = 403;
+						return { success: false, message: "Forbidden" };
+					}
+					return StudentService.deleteAllByClassroom(id, (user as any).sub);
+				},
+				{
+					detail: { summary: "Delete all students in a classroom" },
+				},
+			)
 			.get(
 				"/promote-preview",
 				async ({ query, user, set }) => {

--- a/backend-elysia/src/modules/students/service.ts
+++ b/backend-elysia/src/modules/students/service.ts
@@ -533,4 +533,54 @@ export abstract class StudentService {
     const buffer = Buffer.from(fileBase64, "base64");
     return importStudentsFromXLSX(buffer, userId);
   }
+
+  static async deleteAllByClassroom(classroomId: string, deletedBy: string) {
+    const classroom = await prisma.classroom.findUnique({
+      where: { id: classroomId },
+      select: { id: true, name: true },
+    });
+
+    if (!classroom) throw new NotFoundError("ไม่พบห้องเรียน");
+
+    // Get all students in the classroom with their userIds
+    const students = await prisma.student.findMany({
+      where: { classroomId },
+      select: { id: true, userId: true },
+    });
+
+    const studentIds = students.map((s) => s.id);
+    const userIds = students.map((s) => s.userId).filter((id): id is string => id !== null);
+
+    await prisma.$transaction(async (tx) => {
+      // Delete related records
+      await tx.goodnessIndividual.deleteMany({ where: { studentKey: { in: studentIds } } });
+      await tx.badnessIndividual.deleteMany({ where: { studentKey: { in: studentIds } } });
+      await tx.visitStudent.deleteMany({ where: { studentKey: { in: studentIds } } });
+
+      // Delete users (which will cascade delete students and accounts)
+      if (userIds.length > 0) {
+        await tx.user.deleteMany({ where: { id: { in: userIds } } });
+      }
+
+      // Delete any remaining students without userId
+      await tx.student.deleteMany({ where: { id: { in: studentIds } } });
+
+      // Create audit log
+      await tx.auditLog.create({
+        data: {
+          action: "DELETE_ALL_CLASSROOM_STUDENTS",
+          model: "Student",
+          detail: `ลบนักเรียนทั้งหมด ${students.length} คน จากห้อง "${classroom.name}"`,
+          oldValue: classroom.id,
+          newValue: null,
+          createdBy: deletedBy,
+        },
+      });
+    });
+
+    return {
+      deleted: students.length,
+      classroom: classroom.name,
+    };
+  }
 }

--- a/frontend/src/@core/components/dialogs/ConfirmDialog.tsx
+++ b/frontend/src/@core/components/dialogs/ConfirmDialog.tsx
@@ -84,7 +84,7 @@ const ConfirmDialog = ({ open, options, onClose, onConfirm, isConfirming = false
             mb: 3,
           }}
         >
-          <IconComponent width={32} height={32} />
+          <IconComponent size={32} />
         </Box>
         <Typography variant='h6' fontWeight={600} textAlign='center' id={`${severity}-confirm-dialog-title`}>
           {title}

--- a/frontend/src/components/dialogs/StudentBulkDeleteDialog.tsx
+++ b/frontend/src/components/dialogs/StudentBulkDeleteDialog.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { memo } from 'react';
+import { Typography } from '@mui/material';
+
+import ConfirmDialog, { type ConfirmDialogOptions } from '@/@core/components/dialogs/ConfirmDialog';
+
+interface StudentBulkDeleteDialogProps {
+  open: boolean;
+  classroomName: string;
+  studentCount: number;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const StudentBulkDeleteDialog = memo(({ open, classroomName, studentCount, isDeleting, onClose, onConfirm }: StudentBulkDeleteDialogProps) => {
+  const options: ConfirmDialogOptions = {
+    title: 'ยืนยันการลบนักเรียนทั้งหมด',
+    message: (
+      <>
+        คุณต้องการลบนักเรียนทั้งหมด{' '}
+        <Typography component='span' sx={{ color: 'error.main', fontWeight: 600 }}>
+          {studentCount} คน
+        </Typography>
+        {' จากห้อง '}
+        <Typography component='span' sx={{ color: 'text.primary', fontWeight: 600 }}>
+          {classroomName}
+        </Typography>
+        {' ใช่หรือไม่?'}
+      </>
+    ),
+    severity: 'error',
+    confirmText: 'ลบทั้งหมด',
+    cancelText: 'ยกเลิก',
+    showWarning: true,
+    warningMessage: 'การดำเนินการนี้ไม่สามารถย้อนกลับได้ ข้อมูลนักเรียนและข้อมูลที่เกี่ยวข้องทั้งหมดจะถูกลบออกจากระบบ',
+  };
+
+  return <ConfirmDialog open={open} options={options} onClose={onClose} onConfirm={onConfirm} isConfirming={isDeleting} />;
+});
+
+StudentBulkDeleteDialog.displayName = 'StudentBulkDeleteDialog';
+
+export default StudentBulkDeleteDialog;

--- a/frontend/src/hooks/features/student/useStudentList.tsx
+++ b/frontend/src/hooks/features/student/useStudentList.tsx
@@ -14,6 +14,7 @@ import {
   useGraduateClassroom,
   usePromoteStudents,
   usePromotePreview,
+  useDeleteAllClassroom,
   type StudentImportResult,
 } from '@/hooks/queries/useStudents';
 
@@ -41,6 +42,10 @@ interface UseStudentListReturn {
   openDeletedConfirm: boolean;
   deletedStudent: any | null;
   isDeleting: boolean;
+
+  // Bulk delete dialog state
+  openBulkDeleteConfirm: boolean;
+  isDeletingAll: boolean;
 
   // Graduation dialog state
   openGraduationConfirm: boolean;
@@ -83,6 +88,9 @@ interface UseStudentListReturn {
   handleDeleteClick: (student: any) => void;
   handleDeleteConfirm: () => void;
   handleDeleteCancel: () => void;
+  handleBulkDeleteClick: () => void;
+  handleBulkDeleteConfirm: () => void;
+  handleBulkDeleteCancel: () => void;
   handleGraduationClick: (student: any) => void;
   handleGraduationConfirm: (graduationDate: Date) => void;
   handleGraduationCancel: () => void;
@@ -149,6 +157,7 @@ export const useStudentList = (): UseStudentListReturn => {
 
   const { data: allClassrooms = [], isLoading: loadingClassroom } = useClassrooms();
   const { mutate: deleteStudent } = useDeleteStudent();
+  const { mutate: deleteAllClassroom, isPending: isDeletingAll } = useDeleteAllClassroom();
   const { mutate: graduateStudent } = useGraduateStudent();
   const { mutate: graduateClassroom } = useGraduateClassroom();
   const { mutateAsync: importStudents, isPending: isImportingStudents } = useImportStudents();
@@ -165,6 +174,7 @@ export const useStudentList = (): UseStudentListReturn => {
   const [openDeletedConfirm, setOpenDeletedConfirm] = useState(false);
   const [deletedStudent, setDeletedStudent] = useState<any | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [openBulkDeleteConfirm, setOpenBulkDeleteConfirm] = useState(false);
   const [openGraduationConfirm, setOpenGraduationConfirm] = useState(false);
   const [graduationStudent, setGraduationStudent] = useState<any | null>(null);
   const [isGraduating, setIsGraduating] = useState(false);
@@ -222,7 +232,7 @@ export const useStudentList = (): UseStudentListReturn => {
       search: deferredSearchValue,
       studentStatus: deferredSearchValue.studentStatus || undefined,
     },
-    { enabled: currentClassroomId !== null },
+    { enabled: true },
   );
 
   // ─── Handlers ────────────────────────────────────────────────────────────────
@@ -298,6 +308,34 @@ export const useStudentList = (): UseStudentListReturn => {
   const handleDeleteCancel = useCallback(() => {
     setOpenDeletedConfirm(false);
     setDeletedStudent(null);
+  }, []);
+
+  const handleBulkDeleteClick = useCallback(() => {
+    if (!students.length) {
+      toast.warn('ไม่มีนักเรียนในห้องนี้');
+      return;
+    }
+    setOpenBulkDeleteConfirm(true);
+  }, [students.length]);
+
+  const handleBulkDeleteConfirm = useCallback(() => {
+    if (!currentClassroomId) return;
+    const toastId = toast.info('กำลังลบนักเรียนทั้งหมด...', { autoClose: false, hideProgressBar: true });
+    deleteAllClassroom(currentClassroomId, {
+      onSuccess: (result) => {
+        setOpenBulkDeleteConfirm(false);
+        toast.dismiss(toastId);
+        toast.success(`ลบนักเรียน ${result.deleted} คน จากห้อง ${result.classroom} สำเร็จ`);
+      },
+      onError: () => {
+        toast.dismiss(toastId);
+        toast.error('เกิดข้อผิดพลาดในการลบข้อมูล');
+      },
+    });
+  }, [currentClassroomId, deleteAllClassroom]);
+
+  const handleBulkDeleteCancel = useCallback(() => {
+    setOpenBulkDeleteConfirm(false);
   }, []);
 
   const handleGraduationClick = useCallback((student: any) => {
@@ -620,6 +658,8 @@ export const useStudentList = (): UseStudentListReturn => {
     openDeletedConfirm,
     deletedStudent,
     isDeleting,
+    openBulkDeleteConfirm,
+    isDeletingAll,
     openGraduationConfirm,
     graduationStudent,
     isGraduating,
@@ -648,6 +688,9 @@ export const useStudentList = (): UseStudentListReturn => {
     handleDeleteClick,
     handleDeleteConfirm,
     handleDeleteCancel,
+    handleBulkDeleteClick,
+    handleBulkDeleteConfirm,
+    handleBulkDeleteCancel,
     handleGraduationClick,
     handleGraduationConfirm,
     handleGraduationCancel,

--- a/frontend/src/hooks/queries/useStudents.ts
+++ b/frontend/src/hooks/queries/useStudents.ts
@@ -296,6 +296,28 @@ export const useGraduateClassroom = () => {
   });
 };
 
+export interface DeleteAllClassroomResult {
+  deleted: number;
+  classroom: string;
+}
+
+/**
+ * Hook to delete all students in a classroom
+ */
+export const useDeleteAllClassroom = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (classroomId: string) => {
+      const { data } = await httpClient.delete(`${authConfig.studentEndpoint}/classroom/${classroomId}`);
+      return data as DeleteAllClassroomResult;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.students.all });
+    },
+  });
+};
+
 /**
  * Hook to mark a student as graduated
  */

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -29,6 +29,7 @@ import RenderAvatar from '@/@core/components/avatar';
 import TableHeader from '@/views/apps/student/list/TableHeader';
 import ClassroomPromotionDialog from '@/views/apps/settings/classroom/ClassroomPromotionDialog';
 import StudentDeleteDialog from '@/components/dialogs/StudentDeleteDialog';
+import StudentBulkDeleteDialog from '@/components/dialogs/StudentBulkDeleteDialog';
 import StudentGraduationDialog from '@/components/dialogs/StudentGraduationDialog';
 import StudentBulkGraduationDialog from '@/components/dialogs/StudentBulkGraduationDialog';
 import StudentIndividualPromotionDialog from '@/components/dialogs/StudentIndividualPromotionDialog';
@@ -222,6 +223,8 @@ const StudentListPage = () => {
     openDeletedConfirm,
     deletedStudent,
     isDeleting,
+    openBulkDeleteConfirm,
+    isDeletingAll,
     openGraduationConfirm,
     graduationStudent,
     isGraduating,
@@ -251,6 +254,9 @@ const StudentListPage = () => {
     handleDeleteClick,
     handleDeleteConfirm,
     handleDeleteCancel,
+    handleBulkDeleteClick,
+    handleBulkDeleteConfirm,
+    handleBulkDeleteCancel,
     handleGraduationClick,
     handleGraduationConfirm,
     handleGraduationCancel,
@@ -519,6 +525,7 @@ const StudentListPage = () => {
               onExportStudents={handleExportStudents}
               onBulkGraduate={isAdmin ? handleBulkGraduationClick : undefined}
               onBulkPromote={isAdmin ? handlePromoteClick : undefined}
+              onDeleteAll={isAdmin ? handleBulkDeleteClick : undefined}
               onStatusChange={handleStatusChange}
               studentStatus={searchValue.studentStatus}
               studentId={searchValue.studentId}
@@ -528,6 +535,7 @@ const StudentListPage = () => {
               isDownloadingTemplate={isDownloadingTemplate}
               isExportingStudents={isExportingStudents}
               isPromoting={isPromoting}
+              isDeleting={isDeletingAll}
             />
             <StyledDataGrid
               rows={students}
@@ -555,6 +563,16 @@ const StudentListPage = () => {
           isDeleting={isDeleting}
           onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
+        />
+      )}
+      {openBulkDeleteConfirm && (
+        <StudentBulkDeleteDialog
+          open={openBulkDeleteConfirm}
+          classroomName={initClassroom?.name ?? ''}
+          studentCount={students.length}
+          isDeleting={isDeletingAll}
+          onClose={handleBulkDeleteCancel}
+          onConfirm={handleBulkDeleteConfirm}
         />
       )}
       {openGraduationConfirm && (

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -24,6 +24,7 @@ interface TableHeaderProps {
   onExportStudents: () => Promise<void>;
   onBulkGraduate?: () => void;
   onBulkPromote?: () => void;
+  onDeleteAll?: () => void;
   onStatusChange: (status: string) => void;
   studentStatus: string;
   studentId: string;
@@ -33,6 +34,7 @@ interface TableHeaderProps {
   isDownloadingTemplate: boolean;
   isExportingStudents: boolean;
   isPromoting?: boolean;
+  isDeleting?: boolean;
 }
 
 const PANEL_RADIUS = 16;
@@ -163,6 +165,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
     onExportStudents,
     onBulkGraduate,
     onBulkPromote,
+    onDeleteAll,
     onStatusChange,
     studentStatus,
     studentId,
@@ -172,6 +175,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
     isDownloadingTemplate,
     isExportingStudents,
     isPromoting,
+    isDeleting,
   } = props;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -362,6 +366,29 @@ const TableHeader = memo((props: TableHeaderProps) => {
                         disabled={isPromoting}
                       >
                         <Icon icon='tabler:arrow-up' />
+                      </ToolButton>
+                    </ToolButtonSlot>
+                  </Tooltip>
+                  <ToolDivider />
+                </>
+              )}
+
+              {onDeleteAll && (
+                <>
+                  <Tooltip title={isDeleting ? 'กำลังลบ...' : 'ลบนักเรียนทั้งหมดในห้อง'}>
+                    <ToolButtonSlot component='span'>
+                      <ToolButton
+                        id='delete-all-students-button'
+                        onClick={onDeleteAll}
+                        disabled={isDeleting}
+                        sx={{
+                          color: 'error.main',
+                          '&:hover': {
+                            backgroundColor: (theme) => alpha(theme.palette.error.main, 0.12),
+                          },
+                        }}
+                      >
+                        <Icon icon='tabler:trash' />
                       </ToolButton>
                     </ToolButtonSlot>
                   </Tooltip>


### PR DESCRIPTION
## Summary
- Add **Delete All Students** feature for each classroom (admin only)
- Improve confirm dialog icon size (16px → 32px)
- Fix student search to work without classroom selection

## Changes

### Backend (`backend-elysia`)
- `students/service.ts`: Add `deleteAllByClassroom()` method
  - Deletes all students, users, and related records (goodness, badness, visits)
  - Creates audit log entry
- `students/index.ts`: Add `DELETE /students/classroom/:id` endpoint

### Frontend (`frontend`)
- New: `StudentBulkDeleteDialog.tsx` - Confirmation dialog with student count
- `useStudents.ts`: Add `useDeleteAllClassroom` hook
- `useStudentList.tsx`: Add bulk delete handlers and state
- `TableHeader.tsx`: Add delete all button (trash icon, admin only)
- `StudentListPage.tsx`: Wire up bulk delete dialog
- `ConfirmDialog.tsx`: Increase icon size from 16px to 32px
- Fix: Remove `classroomId` requirement from query enable condition

## Test Plan
- [ ] Delete all students in a classroom (admin only)
- [ ] Verify confirmation dialog shows correct student count
- [ ] Verify warning message about irreversible action
- [ ] Test search without classroom selection
- [ ] Verify icon size is larger in all confirm dialogs