### PR TITLE
feat(nav): marquee scroll for long sidebar menu titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,7 @@ Thumbs.db
 .eslintcache
 .stylelintcache
 .parcel-cache/
-.next-env.d.ts
+next-env.d.ts
 
 # ===== LEGACY/OLD FILES =====
 web/

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ $RECYCLE.BIN/
 .Trash-*
 backend/src/database/generated/*
 .claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,11 @@ nktc-app/
 - **Next.js 16.0.1** with App Router and Turbopack bundler
 - **React 19.2.0** with functional components and hooks
 - **TypeScript 5.9.3** for type safety
-- **Material-UI 7.3.5** as primary UI framework
-  - MUI Icons Material 7.3.5
-  - MUI Lab 7.0.1-beta.19
-  - MUI X Data Grid 8.17.0
-  - MUI X Date Pickers 8.17.0
+- **Material-UI 9.0.1** as primary UI framework (MUI v9)
+  - MUI Icons Material 9.0.1
+  - MUI Lab 9.0.0-beta.3
+  - MUI X Data Grid 8.28.6
+  - MUI X Date Pickers 9.2.0
 - **Zustand 5.0.8** for global state management
 - **React Query 5.90.7** (@tanstack/react-query) for server state management
 - **React Hook Form 7.66.0 + Yup 1.7.1** for form handling and validation
@@ -412,7 +412,7 @@ MINIO_PORT=9000
 ### MCP Servers
 
 - **MUI MCP**: Material-UI documentation and component reference via Model Context Protocol
-  - Provides AI assistants with direct access to official MUI v7 documentation
+  - Provides AI assistants with direct access to official MUI v9 documentation
   - Installation: `claude mcp add mui-mcp -- npx -y @mui/mcp@latest`
   - Status: ✓ Connected (Project-scoped)
   - Usage: Automatically available when working with MUI components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ When working with frontend state:
 - Material-UI components over custom HTML elements
 - Consistent naming: PascalCase for components, camelCase for functions
 - File naming: kebab-case for files and directories
+- **Every interactive HTML element and MUI component must have an `id` prop** — buttons, inputs, selects, dialogs, forms, toolbars, data grids, etc. Use kebab-case descriptive IDs (e.g., `id='add-student-button'`, `id='student-search-input'`)
 
 ### Styling Approach
 

--- a/backend-elysia/src/__tests__/rbac.test.ts
+++ b/backend-elysia/src/__tests__/rbac.test.ts
@@ -43,9 +43,9 @@ describe("requireRoles", () => {
     mockFindUnique.mockReset();
   });
 
-  it("returns 403 when no Authorization header (null user)", async () => {
+  it("returns 401 when no Authorization header (unauthenticated)", async () => {
     const res = await adminApp.handle(new Request("http://localhost/admin"));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("returns 403 when user role does not match", async () => {

--- a/backend-elysia/src/__tests__/students.service.extra.test.ts
+++ b/backend-elysia/src/__tests__/students.service.extra.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 const mockStudentFindMany = mock();
 const mockStudentCount = mock();
 const mockStudentFindUnique = mock();
+const mockUserFindMany = mock();
 const mockUserFindFirst = mock();
 const mockGoodnessAggregate = mock();
 const mockBadnessAggregate = mock();
@@ -45,7 +46,7 @@ mock.module("@/libs/prisma", () => ({
       findUnique: mockStudentFindUnique,
       updateMany: mockStudentUpdateMany,
     },
-    user: { findFirst: mockUserFindFirst },
+    user: { findMany: mockUserFindMany, findFirst: mockUserFindFirst },
     goodnessIndividual: { aggregate: mockGoodnessAggregate },
     badnessIndividual: { aggregate: mockBadnessAggregate },
     teacherOnClassroom: { findMany: mockTeacherOnClassroomFindMany },
@@ -92,7 +93,7 @@ const STUDENT_NULL_USER = { id: "s4", userId: null, user: null };
 
 function resetAll() {
   for (const m of [
-    mockStudentFindMany, mockStudentCount, mockStudentFindUnique, mockUserFindFirst,
+    mockStudentFindMany, mockStudentCount, mockStudentFindUnique, mockUserFindMany, mockUserFindFirst,
     mockGoodnessAggregate, mockBadnessAggregate, mockTeacherOnClassroomFindMany,
     mockTeacherFindMany, mockClassroomFindUnique, mockStudentUpdateMany, mockAuditLogCreate,
     mockGoodnesDeleteMany, mockBadnessDeleteMany, mockVisitDeleteMany,
@@ -103,6 +104,7 @@ function resetAll() {
   ]) m.mockReset();
 
   mockTransaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx));
+  mockUserFindMany.mockResolvedValue([]);
   mockGoodnesDeleteMany.mockResolvedValue({ count: 0 });
   mockBadnessDeleteMany.mockResolvedValue({ count: 0 });
   mockVisitDeleteMany.mockResolvedValue({ count: 0 });
@@ -207,11 +209,11 @@ describe("StudentService.searchWithParams", () => {
     expect(result.data).toHaveLength(1);
   });
 
-  it("applies studentStatus filter for 'graduated'", async () => {
+  it("applies studentStatus filter for 'จบการศึกษา'", async () => {
     mockStudentFindMany.mockResolvedValueOnce([]);
     mockStudentCount.mockResolvedValueOnce(0);
 
-    await StudentService.searchWithParams({ studentStatus: "graduated" } as any);
+    await StudentService.searchWithParams({ studentStatus: "จบการศึกษา" } as any);
     const callArg = mockStudentFindMany.mock.calls[0][0] as any;
     expect(callArg.where.OR).toBeDefined();
   });

--- a/backend-elysia/src/middleware/auth.ts
+++ b/backend-elysia/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { jwt } from "@elysiajs/jwt";
 import { prisma } from "@/libs/prisma";
+import { UnauthorizedError } from "@/libs/errors";
 
 export type JwtPayload = { sub: string; username: string; roles: string };
 
@@ -43,4 +44,7 @@ export const authGuard = new Elysia({ name: "auth-guard" })
     const user: JwtPayload = { sub: dbUser.id, username: dbUser.username, roles: dbUser.role as string };
     userCache.set(sub, { user, expiresAt: Date.now() + CACHE_TTL_MS });
     return { user };
+  })
+  .onBeforeHandle({ as: "global" }, ({ user }) => {
+    if (!user) throw new UnauthorizedError();
   });

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/@core/components/data-grid/AppDataGrid.ts
+++ b/frontend/src/@core/components/data-grid/AppDataGrid.ts
@@ -1,0 +1,76 @@
+import { DataGrid } from '@mui/x-data-grid';
+import { alpha, styled } from '@mui/material/styles';
+
+/**
+ * Project-standard DataGrid with consistent visual styles.
+ *
+ * Usage:
+ *   import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+ *
+ * To add first-column padding (px 3/4/5 responsive), extend per page:
+ *   const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
+ *     '& .MuiDataGrid-columnHeader[data-field="<firstField>"]': {
+ *       paddingLeft: theme.spacing(3),
+ *       [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+ *       [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+ *     },
+ *     '& .MuiDataGrid-cell[data-field="<firstField>"]': {
+ *       paddingLeft: theme.spacing(3),
+ *       [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+ *       [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+ *     },
+ *   }));
+ *
+ * Last column named "actions" or "action" gets paddingRight automatically.
+ */
+const AppDataGrid = styled(DataGrid)(({ theme }) => ({
+  border: 0,
+  '& .MuiDataGrid-row': {
+    maxHeight: 'none !important',
+    transition: 'background-color 180ms ease',
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.main, 0.04),
+    },
+  },
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: alpha(theme.palette.primary.main, 0.04),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+  },
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontWeight: 700,
+    color: theme.palette.text.primary,
+  },
+  '& .MuiDataGrid-cell': {
+    display: 'flex',
+    alignItems: 'center',
+    lineHeight: 'unset !important',
+    maxHeight: 'none !important',
+    overflow: 'visible',
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+  },
+  '& .MuiDataGrid-renderingZone': {
+    maxHeight: 'none !important',
+  },
+  '& .MuiDataGrid-footerContainer': {
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+    backgroundColor: alpha(theme.palette.background.paper, 0.7),
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
+  },
+  // Last-column padding — covers "actions" (list pages) and "action" (report pages)
+  '& .MuiDataGrid-columnHeader[data-field="actions"], & .MuiDataGrid-columnHeader[data-field="action"]': {
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="actions"], & .MuiDataGrid-cell[data-field="action"]': {
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
+  },
+}));
+
+export default AppDataGrid;

--- a/frontend/src/@core/components/data-grid/AppListDataGrid.ts
+++ b/frontend/src/@core/components/data-grid/AppListDataGrid.ts
@@ -23,6 +23,20 @@ const AppListDataGrid = styled(AppDataGrid)(({ theme }) => ({
 
 export default AppListDataGrid;
 
+// Settings-variant: first column is "name" (department/program/classroom)
+export const AppSettingsDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-columnHeader[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+}));
+
 // Teacher-variant: zebra rows + stronger column header accents
 export const AppTeacherDataGrid = styled(AppListDataGrid)(({ theme }) => ({
   '& .MuiDataGrid-row': {

--- a/frontend/src/@core/components/data-grid/AppListDataGrid.ts
+++ b/frontend/src/@core/components/data-grid/AppListDataGrid.ts
@@ -35,6 +35,23 @@ export const AppSettingsDataGrid = styled(AppDataGrid)(({ theme }) => ({
     [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
     [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
+  '& .MuiDataGrid-row': {
+    '&:nth-of-type(even)': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.035 : 0.02),
+    },
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.1 : 0.045),
+    },
+  },
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.06),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+    borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.18)}`,
+  },
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontSize: '0.8rem',
+    letterSpacing: '0.02em',
+  },
 }));
 
 // Teacher-variant: zebra rows + stronger column header accents

--- a/frontend/src/@core/components/data-grid/AppListDataGrid.ts
+++ b/frontend/src/@core/components/data-grid/AppListDataGrid.ts
@@ -1,0 +1,45 @@
+import { alpha, styled } from '@mui/material/styles';
+import AppDataGrid from './AppDataGrid';
+
+/**
+ * Extends AppDataGrid for list pages (student, teacher).
+ * Adds responsive paddingLeft on the "fullName" first column.
+ *
+ * For zebra rows or stronger column headers, extend further per page:
+ *   const StyledDataGrid = styled(AppListDataGrid)(({ theme }) => ({ ... }));
+ */
+const AppListDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+}));
+
+export default AppListDataGrid;
+
+// Teacher-variant: zebra rows + stronger column header accents
+export const AppTeacherDataGrid = styled(AppListDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-row': {
+    '&:nth-of-type(even)': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.035 : 0.02),
+    },
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.12 : 0.055),
+    },
+  },
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.14)}`,
+    borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+  },
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontSize: '0.8rem',
+    letterSpacing: '0.02em',
+  },
+}));

--- a/frontend/src/@core/components/filter-panel/index.ts
+++ b/frontend/src/@core/components/filter-panel/index.ts
@@ -1,0 +1,71 @@
+import { Box, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import { alpha, styled } from '@mui/material/styles';
+
+const PANEL_RADIUS = 16;
+
+const getPanelBorderColor = (theme: any) =>
+  alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1);
+
+const getPanelShadowColor = (theme: any) =>
+  theme.palette.mode === 'dark'
+    ? alpha(theme.palette.common.black, 0.28)
+    : alpha(theme.palette.primary.main, 0.06);
+
+export const SectionBox = styled(Box)(({ theme }) => ({
+  width: '100%',
+  borderRadius: PANEL_RADIUS,
+  border: `1px solid ${getPanelBorderColor(theme)}`,
+  background:
+    theme.palette.mode === 'dark'
+      ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 34%, ${alpha(theme.palette.secondary.main, 0.08)} 100%)`
+      : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 38%, ${alpha(theme.palette.secondary.main, 0.04)} 100%)`,
+  boxShadow: `0 12px 28px ${getPanelShadowColor(theme)}`,
+  padding: theme.spacing(2),
+  [theme.breakpoints.up('sm')]: {
+    padding: theme.spacing(3),
+  },
+  [theme.breakpoints.up('lg')]: {
+    padding: theme.spacing(3.5),
+  },
+}));
+
+export const SectionTitle = styled(Typography)(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  fontSize: 'clamp(0.92rem, 0.86rem + 0.16vw, 1rem)',
+  fontWeight: 800,
+  letterSpacing: '-0.01em',
+  color: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.88 : 0.82),
+  textShadow:
+    theme.palette.mode === 'dark' ? `0 1px 10px ${alpha(theme.palette.primary.main, 0.12)}` : 'none',
+  '&::before': {
+    content: '""',
+    width: 10,
+    height: 10,
+    borderRadius: 999,
+    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.72 : 0.64),
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? `0 0 0 6px ${alpha(theme.palette.primary.main, 0.08)}`
+        : `0 0 0 5px ${alpha(theme.palette.primary.main, 0.08)}`,
+  },
+}));
+
+export const SectionDescription = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(0.5),
+  color:
+    theme.palette.mode === 'dark'
+      ? alpha(theme.palette.text.primary, 0.82)
+      : theme.palette.text.secondary,
+  maxWidth: '62ch',
+  fontSize: 'clamp(0.94rem, 0.9rem + 0.18vw, 1.06rem)',
+  fontWeight: 500,
+  lineHeight: 1.6,
+}));
+
+export const FilterGrid = styled(Grid)({
+  display: 'flex',
+  alignItems: 'center',
+});

--- a/frontend/src/@core/components/form/index.ts
+++ b/frontend/src/@core/components/form/index.ts
@@ -1,32 +1,20 @@
+import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 import { alpha, styled } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 
-// ─── Shared filter-control styles ─────────────────────────────────────────────
-// Applied to both AppFilterTextField and AppFilterFormControl so Select and
-// TextField/Autocomplete share the same visual language inside filter panels.
+// ─── Style helpers ─────────────────────────────────────────────────────────────
 
-const filterControlStyles = (theme: Theme) => ({
-  '& .MuiOutlinedInput-root': {
-    borderRadius: 12,
-    backgroundColor: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.82),
-    color: theme.palette.text.primary,
-    fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
-    '& fieldset': {
-      borderColor: alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-    },
-    '&:hover fieldset': {
-      borderColor: alpha(theme.palette.primary.main, 0.28),
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: theme.palette.primary.main,
-    },
-  },
-  '& .MuiInputBase-input': {
-    letterSpacing: '-0.01em',
-  },
+const filterBorderColor = (theme: Theme) =>
+  alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12);
+
+const filterBg = (theme: Theme) =>
+  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.82);
+
+const filterLabelStyles = (theme: Theme) => ({
   '& .MuiInputLabel-root': {
     fontSize: '0.9rem',
     fontWeight: 600,
@@ -35,50 +23,93 @@ const filterControlStyles = (theme: Theme) => ({
   '& .MuiInputLabel-shrink': {
     fontSize: '0.86rem',
   },
-  '& .MuiSvgIcon-root': {
-    color: theme.palette.text.secondary,
-  },
   '& .MuiFormHelperText-root:not(.Mui-error)': {
     color: theme.palette.text.secondary,
     fontWeight: 500,
   },
 });
 
-// TextField for filter panels and form fields
-export const AppFilterTextField = styled(TextField)(({ theme }) => filterControlStyles(theme));
+// ─── AppFilterTextField ────────────────────────────────────────────────────────
+// Styled TextField for filter panels and form fields.
 
-// FormControl wrapper for Select inside filter panels (same visual as AppFilterTextField)
-export const AppFilterFormControl = styled(FormControl)(({ theme }) => filterControlStyles(theme));
+export const AppFilterTextField = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 12,
+    backgroundColor: filterBg(theme),
+    color: theme.palette.text.primary,
+    fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
+    '& fieldset': { borderColor: filterBorderColor(theme) },
+    '&:hover fieldset': { borderColor: alpha(theme.palette.primary.main, 0.28) },
+    '&.Mui-focused fieldset': { borderColor: theme.palette.primary.main },
+  },
+  '& .MuiInputBase-input': { letterSpacing: '-0.01em' },
+  '& .MuiSvgIcon-root': { color: theme.palette.text.secondary },
+  ...filterLabelStyles(theme),
+}));
 
-// ─── Search TextField ──────────────────────────────────────────────────────────
-// Toolbar search bar with primary-tinted border and focus shadow
+// ─── AppFilterSelect ───────────────────────────────────────────────────────────
+// Styled Select for filter panels. Use inside AppFilterFormControl for labels.
+
+export const AppFilterSelect = styled(Select)(({ theme }) => ({
+  borderRadius: 12,
+  backgroundColor: filterBg(theme),
+  fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
+  '& .MuiSelect-select': { letterSpacing: '-0.01em' },
+  '& .MuiOutlinedInput-notchedOutline': { borderColor: filterBorderColor(theme) },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: alpha(theme.palette.primary.main, 0.28),
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: theme.palette.primary.main,
+  },
+  '& .MuiSvgIcon-root': { color: theme.palette.text.secondary },
+})) as unknown as typeof Select;
+
+// ─── AppFilterFormControl ──────────────────────────────────────────────────────
+// FormControl wrapper — applies label styling when using AppFilterSelect.
+// Does NOT style the input (AppFilterSelect handles its own border/bg).
+
+export const AppFilterFormControl = styled(FormControl)(({ theme }) => filterLabelStyles(theme));
+
+// ─── AppFilterAutocomplete ─────────────────────────────────────────────────────
+// Styled Autocomplete for filter panels.
+// Use AppFilterTextField in renderInput for input styling.
+
+export const AppFilterAutocomplete = styled(Autocomplete)(({ theme }) => ({
+  '& + .MuiAutocomplete-popper .MuiAutocomplete-paper': {
+    borderRadius: 12,
+    border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+    boxShadow: `0 8px 24px ${alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.32 : 0.1)}`,
+  },
+  '& + .MuiAutocomplete-popper .MuiAutocomplete-option': {
+    fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
+    letterSpacing: '-0.01em',
+  },
+})) as typeof Autocomplete;
+
+// ─── AppSearchTextField ────────────────────────────────────────────────────────
+// Toolbar search bar with primary-tinted border and focus glow.
 
 export const AppSearchTextField = styled(TextField)(({ theme }) => ({
   '& .MuiOutlinedInput-root': {
     borderRadius: theme.spacing(2.5),
     backgroundColor: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.9 : 0.96),
     transition: 'border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
-    '& .MuiInputAdornment-root': {
-      color: theme.palette.primary.main,
-    },
+    '& .MuiInputAdornment-root': { color: theme.palette.primary.main },
     '& fieldset': {
       borderColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
     },
-    '&:hover fieldset': {
-      borderColor: alpha(theme.palette.primary.main, 0.38),
-    },
+    '&:hover fieldset': { borderColor: alpha(theme.palette.primary.main, 0.38) },
     '&.Mui-focused': {
       backgroundColor: theme.palette.background.paper,
       boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.1)}`,
     },
-    '&.Mui-focused fieldset': {
-      borderColor: theme.palette.primary.main,
-    },
+    '&.Mui-focused fieldset': { borderColor: theme.palette.primary.main },
   },
 }));
 
-// ─── Contained Button ──────────────────────────────────────────────────────────
-// Primary action button (add/submit) with elevation shadow
+// ─── AppContainedButton ────────────────────────────────────────────────────────
+// Primary action button (add/submit) with elevation shadow.
 
 export const AppContainedButton = styled(Button)(({ theme }) => ({
   borderRadius: theme.spacing(2.5),

--- a/frontend/src/@core/components/form/index.ts
+++ b/frontend/src/@core/components/form/index.ts
@@ -1,0 +1,92 @@
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import TextField from '@mui/material/TextField';
+import { alpha, styled } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+
+// ─── Shared filter-control styles ─────────────────────────────────────────────
+// Applied to both AppFilterTextField and AppFilterFormControl so Select and
+// TextField/Autocomplete share the same visual language inside filter panels.
+
+const filterControlStyles = (theme: Theme) => ({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 12,
+    backgroundColor: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.82),
+    color: theme.palette.text.primary,
+    fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
+    '& fieldset': {
+      borderColor: alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
+    },
+    '&:hover fieldset': {
+      borderColor: alpha(theme.palette.primary.main, 0.28),
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: theme.palette.primary.main,
+    },
+  },
+  '& .MuiInputBase-input': {
+    letterSpacing: '-0.01em',
+  },
+  '& .MuiInputLabel-root': {
+    fontSize: '0.9rem',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+  },
+  '& .MuiInputLabel-shrink': {
+    fontSize: '0.86rem',
+  },
+  '& .MuiSvgIcon-root': {
+    color: theme.palette.text.secondary,
+  },
+  '& .MuiFormHelperText-root:not(.Mui-error)': {
+    color: theme.palette.text.secondary,
+    fontWeight: 500,
+  },
+});
+
+// TextField for filter panels and form fields
+export const AppFilterTextField = styled(TextField)(({ theme }) => filterControlStyles(theme));
+
+// FormControl wrapper for Select inside filter panels (same visual as AppFilterTextField)
+export const AppFilterFormControl = styled(FormControl)(({ theme }) => filterControlStyles(theme));
+
+// ─── Search TextField ──────────────────────────────────────────────────────────
+// Toolbar search bar with primary-tinted border and focus shadow
+
+export const AppSearchTextField = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: theme.spacing(2.5),
+    backgroundColor: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.9 : 0.96),
+    transition: 'border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
+    '& .MuiInputAdornment-root': {
+      color: theme.palette.primary.main,
+    },
+    '& fieldset': {
+      borderColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
+    },
+    '&:hover fieldset': {
+      borderColor: alpha(theme.palette.primary.main, 0.38),
+    },
+    '&.Mui-focused': {
+      backgroundColor: theme.palette.background.paper,
+      boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.1)}`,
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: theme.palette.primary.main,
+    },
+  },
+}));
+
+// ─── Contained Button ──────────────────────────────────────────────────────────
+// Primary action button (add/submit) with elevation shadow
+
+export const AppContainedButton = styled(Button)(({ theme }) => ({
+  borderRadius: theme.spacing(2.5),
+  whiteSpace: 'nowrap',
+  padding: `${theme.spacing(1)} ${theme.spacing(3)}`,
+  minHeight: 40,
+  boxShadow: `0 8px 18px ${alpha(theme.palette.primary.main, 0.24)}`,
+  '&:hover': {
+    boxShadow: `0 10px 24px ${alpha(theme.palette.primary.main, 0.3)}`,
+  },
+}));

--- a/frontend/src/@core/components/icon/index.tsx
+++ b/frontend/src/@core/components/icon/index.tsx
@@ -1,8 +1,33 @@
 // ** Icon Imports
 import { Icon, IconProps } from '@iconify/react';
+import Box from '@mui/material/Box';
 
 const IconifyIcon = ({ icon, fontSize = '1.5rem', ...rest }: IconProps) => {
   return <Icon icon={icon} fontSize={fontSize} {...rest} />;
 };
 
 export default IconifyIcon;
+
+type SemanticColor = 'primary' | 'secondary' | 'success' | 'warning' | 'info' | 'error';
+
+interface ColorIconProps {
+  icon: string;
+  color?: SemanticColor;
+  fontSize?: string | number;
+  opacity?: number;
+}
+
+/** Icon wrapped in a colored inline span. Inherits theme palette via `color.main`. */
+export const ColorIcon = ({ icon, color, fontSize = '1rem', opacity = 0.8 }: ColorIconProps) => (
+  <Box
+    component='span'
+    sx={{
+      color: color ? `${color}.main` : 'inherit',
+      display: 'inline-flex',
+      flexShrink: 0,
+      opacity,
+    }}
+  >
+    <Icon icon={icon} fontSize={fontSize} />
+  </Box>
+);

--- a/frontend/src/@core/components/list-page/index.tsx
+++ b/frontend/src/@core/components/list-page/index.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { Avatar, Box, Card, CardHeader, Stack, Typography } from '@mui/material';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { alpha, styled } from '@mui/material/styles';
 import type { ReactNode } from 'react';
 

--- a/frontend/src/@core/components/list-page/index.tsx
+++ b/frontend/src/@core/components/list-page/index.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { Avatar, Box, Card, CardHeader, Stack, Typography } from '@mui/material';
+import { alpha, styled } from '@mui/material/styles';
+import type { ReactNode } from 'react';
+
+// ─── AppListCard ──────────────────────────────────────────────────────────────
+
+export const AppListCard = styled(Card)(({ theme }) => ({
+  borderRadius: theme.spacing(3),
+  overflow: 'hidden',
+  border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.08)}`,
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? `0 18px 42px ${alpha(theme.palette.common.black, 0.24)}`
+      : `0 18px 42px ${alpha(theme.palette.primary.main, 0.08)}`,
+  background:
+    theme.palette.mode === 'dark'
+      ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 32%)`
+      : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 32%)`,
+}));
+
+// ─── AppListCardHeader ────────────────────────────────────────────────────────
+
+export interface ListSummaryItem {
+  label: string;
+  value: number | string;
+  color: 'success' | 'warning' | 'error' | 'info' | 'primary' | 'secondary';
+}
+
+interface AppListCardHeaderProps {
+  id?: string;
+  icon: ReactNode;
+  title: string;
+  count?: number;
+  countUnit?: string;
+  description?: string;
+  summaryItems?: ListSummaryItem[];
+}
+
+export const AppListCardHeader = ({
+  id,
+  icon,
+  title,
+  count,
+  countUnit = 'รายการ',
+  description,
+  summaryItems = [],
+}: AppListCardHeaderProps) => (
+  <CardHeader
+    id={id}
+    avatar={
+      <Avatar
+        sx={{
+          color: (theme) => theme.palette.primary.dark,
+          bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.12),
+          border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+          width: { xs: 42, sm: 48 },
+          height: { xs: 42, sm: 48 },
+          boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.16)}`,
+        }}
+      >
+        {icon}
+      </Avatar>
+    }
+    sx={{
+      color: 'text.primary',
+      alignItems: 'flex-start',
+      px: { xs: 3, sm: 4, lg: 5 },
+      pt: { xs: 3, sm: 4.25 },
+      pb: { xs: 2.5, sm: 3 },
+      '& .MuiCardHeader-avatar': { mt: 0.25, mr: { xs: 2, sm: 2.5 } },
+      '& .MuiCardHeader-content': { minWidth: 0 },
+    }}
+    title={
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        sx={{
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          flexWrap: 'wrap',
+          columnGap: { xs: 1, sm: 1.5 },
+          rowGap: 0.75,
+        }}
+      >
+        <Typography
+          component='span'
+          sx={{
+            fontWeight: 800,
+            fontSize: { xs: '1.45rem', sm: '1.9rem' },
+            letterSpacing: { xs: '-0.02em', sm: '-0.03em' },
+            lineHeight: 1.08,
+            color: 'text.primary',
+          }}
+        >
+          {title}
+        </Typography>
+        {count != null && count > 0 && (
+          <Box
+            component='span'
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              gap: 0.75,
+              px: 1.4,
+              py: 0.6,
+              borderRadius: 999,
+              bgcolor: (theme) =>
+                alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+              border: (theme) =>
+                `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.12)}`,
+              color: 'primary.main',
+              lineHeight: 1,
+            }}
+          >
+            <Typography
+              component='span'
+              sx={{
+                fontSize: { xs: '1.05rem', sm: '1.15rem' },
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {count.toLocaleString('th-TH')}
+            </Typography>
+            <Typography
+              component='span'
+              sx={{ fontSize: '0.9rem', fontWeight: 700, letterSpacing: '0.01em', color: 'text.secondary' }}
+            >
+              {countUnit}
+            </Typography>
+          </Box>
+        )}
+      </Stack>
+    }
+    subheader={
+      <Box>
+        {description && (
+          <Typography
+            component='p'
+            sx={{
+              mt: 1.1,
+              fontSize: 'clamp(0.98rem, 0.94rem + 0.16vw, 1.06rem)',
+              fontWeight: 500,
+              letterSpacing: '-0.01em',
+              color: 'text.secondary',
+            }}
+          >
+            {description}
+          </Typography>
+        )}
+        {summaryItems.length > 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: { xs: 0.75, sm: 1 },
+              mt: 2.25,
+              maxWidth: 760,
+            }}
+          >
+            {summaryItems.map((item) => (
+              <Box
+                key={item.label}
+                component='span'
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  px: 1.35,
+                  py: 0.7,
+                  minHeight: 30,
+                  borderRadius: 999,
+                  border: (theme) =>
+                    `1px solid ${alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.26 : 0.18)}`,
+                  bgcolor: (theme) =>
+                    alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.11 : 0.075),
+                }}
+              >
+                <Typography
+                  component='span'
+                  sx={{
+                    fontSize: '0.8rem',
+                    fontWeight: 800,
+                    lineHeight: 1,
+                    color: `${item.color}.dark`,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {typeof item.value === 'number' ? item.value.toLocaleString('th-TH') : item.value}
+                </Typography>
+                <Typography
+                  component='span'
+                  sx={{ fontSize: '0.78rem', fontWeight: 700, lineHeight: 1, color: 'text.secondary' }}
+                >
+                  {item.label}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    }
+    slotProps={{ subheader: { component: 'div' } }}
+  />
+);

--- a/frontend/src/@core/components/toolbar/index.ts
+++ b/frontend/src/@core/components/toolbar/index.ts
@@ -1,0 +1,36 @@
+import { Box, IconButton } from '@mui/material';
+import { alpha, styled } from '@mui/material/styles';
+
+export const ToolButton = styled(IconButton)(({ theme }) => ({
+  width: '100%',
+  minWidth: 54,
+  height: 52,
+  borderRadius: 0,
+  border: 0,
+  backgroundColor: 'transparent',
+  color: theme.palette.primary.main,
+  boxShadow: 'none',
+  transition: 'background-color 180ms ease, color 180ms ease',
+  '&:hover': {
+    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+  },
+}));
+
+export const ToolButtonSlot = styled('span')({
+  display: 'flex',
+  flex: '1 1 0',
+  minWidth: 0,
+});
+
+export const ToolDivider = styled(Box)(({ theme }) => ({
+  width: 1,
+  alignSelf: 'stretch',
+  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.16),
+}));
+
+export const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
+  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.12),
+  '&:hover': {
+    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
+  },
+}));

--- a/frontend/src/@core/layouts/components/vertical/navigation/NavMenuText.tsx
+++ b/frontend/src/@core/layouts/components/vertical/navigation/NavMenuText.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 'use client';
 
 import { useRef, useEffect } from 'react';

--- a/frontend/src/@core/layouts/components/vertical/navigation/NavMenuText.tsx
+++ b/frontend/src/@core/layouts/components/vertical/navigation/NavMenuText.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Translations from '@/layouts/components/Translations';
+
+interface Props {
+  text: string;
+  collapsed: boolean;
+}
+
+const NavMenuText = ({ text, collapsed }: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const textEl = textRef.current;
+    if (!container || !textEl) return;
+
+    if (collapsed) {
+      textEl.style.removeProperty('--nav-scroll-dist');
+      return;
+    }
+
+    const update = () => {
+      const overflow = textEl.scrollWidth - container.clientWidth;
+      textEl.style.setProperty('--nav-scroll-dist', overflow > 4 ? `-${overflow}px` : '0px');
+    };
+
+    const observer = new ResizeObserver(update);
+    observer.observe(container);
+    update();
+
+    return () => observer.disconnect();
+  }, [text, collapsed]);
+
+  return (
+    <Box ref={containerRef} sx={{ overflow: 'hidden', flex: 1, minWidth: 0 }}>
+      <Box ref={textRef} component="span" className="nav-text-inner">
+        <Translations text={text} />
+      </Box>
+    </Box>
+  );
+};
+
+export default NavMenuText;

--- a/frontend/src/@core/layouts/components/vertical/navigation/VerticalNavGroup.tsx
+++ b/frontend/src/@core/layouts/components/vertical/navigation/VerticalNavGroup.tsx
@@ -10,7 +10,6 @@ import { usePathname } from 'next/navigation';
 import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
 import ListItem from '@mui/material/ListItem';
-import Typography from '@mui/material/Typography';
 import Box, { BoxProps } from '@mui/material/Box';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { styled, useTheme } from '@mui/material/styles';
@@ -36,7 +35,7 @@ import { Settings } from '@/@core/context/settingsContext';
 // ** Custom Components Imports
 import VerticalNavItems from './VerticalNavItems';
 import UserIcon from '@/layouts/components/UserIcon';
-import Translations from '@/layouts/components/Translations';
+import NavMenuText from './NavMenuText';
 import CanViewNavGroup from '@/layouts/components/acl/CanViewNavGroup';
 import React from 'react';
 
@@ -258,6 +257,15 @@ const VerticalNavGroup = (props: Props) => {
               transition: 'padding-left .25s ease-in-out',
               pl: navCollapsed && !navHover ? (collapsedNavWidth - navigationBorderWidth - 24) / 8 : 5.5,
               pr: navCollapsed && !navHover ? ((collapsedNavWidth - navigationBorderWidth - 24) / 2 - 5) / 4 : 3.5,
+              '& .nav-text-inner': {
+                display: 'inline-block',
+                whiteSpace: 'nowrap',
+                transform: 'translateX(0)',
+                transition: 'transform 1.5s ease-in-out',
+              },
+              '&:hover .nav-text-inner': {
+                transform: 'translateX(var(--nav-scroll-dist, 0px))',
+              },
             }}
           >
             {isSubToSub ? null : (
@@ -285,13 +293,7 @@ const VerticalNavGroup = (props: Props) => {
                 ...(isSubToSub ? { ml: 9 } : {}),
               }}
             >
-              <Typography
-                {...((themeConfig.menuTextTruncate || (!themeConfig.menuTextTruncate && navCollapsed && !navHover)) && {
-                  noWrap: true,
-                })}
-              >
-                <Translations text={item.title} />
-              </Typography>
+              <NavMenuText text={item.title} collapsed={navCollapsed && !navHover} />
               <Box className='menu-item-meta' sx={{ ml: 0.8, display: 'flex', alignItems: 'center' }}>
                 {item.badgeContent ? (
                   <Chip

--- a/frontend/src/@core/layouts/components/vertical/navigation/VerticalNavLink.tsx
+++ b/frontend/src/@core/layouts/components/vertical/navigation/VerticalNavLink.tsx
@@ -1,6 +1,9 @@
 // ** React Imports
 import { ElementType } from 'react';
 
+// ** Navigation Components
+import NavMenuText from './NavMenuText';
+
 // ** Next Imports
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -9,7 +12,6 @@ import { usePathname } from 'next/navigation';
 import Chip from '@mui/material/Chip';
 import ListItem from '@mui/material/ListItem';
 import { styled } from '@mui/material/styles';
-import Typography from '@mui/material/Typography';
 import Box, { BoxProps } from '@mui/material/Box';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemButton, { ListItemButtonProps } from '@mui/material/ListItemButton';
@@ -23,7 +25,6 @@ import { NavLink, NavGroup } from '@/@core/layouts/types';
 import { Settings } from '@/@core/context/settingsContext';
 
 // ** Custom Components Imports
-import Translations from '@/layouts/components/Translations';
 import CanViewNavLink from '@/layouts/components/acl/CanViewNavLink';
 
 interface Props {
@@ -58,6 +59,15 @@ const MenuNavLink = styled(ListItemButton)<
     '& .MuiTypography-root, & .MuiListItemIcon-root': {
       color: `${theme.palette.common.white} !important`,
     },
+  },
+  '& .nav-text-inner': {
+    display: 'inline-block',
+    whiteSpace: 'nowrap',
+    transform: 'translateX(0)',
+    transition: 'transform 1.5s ease-in-out',
+  },
+  '&:hover .nav-text-inner': {
+    transform: 'translateX(var(--nav-scroll-dist, 0px))',
   },
 }));
 
@@ -182,13 +192,7 @@ const VerticalNavLink = ({
               ...(navCollapsed && !navHover ? { opacity: 0 } : { opacity: 1 }),
             }}
           >
-            <Typography
-              {...((themeConfig.menuTextTruncate || (!themeConfig.menuTextTruncate && navCollapsed && !navHover)) && {
-                noWrap: true,
-              })}
-            >
-              <Translations text={item.title} />
-            </Typography>
+            <NavMenuText text={item.title} collapsed={navCollapsed && !navHover} />
             {item.badgeContent ? (
               <Chip
                 label={item.badgeContent}

--- a/frontend/src/@core/theme/palette/index.ts
+++ b/frontend/src/@core/theme/palette/index.ts
@@ -26,11 +26,11 @@ const DefaultPalette = (mode: PaletteMode, skin: Skin, themeColor: ThemeColor) =
 
   const defaultBgColor = () => {
     if (skin === 'bordered' && mode === 'light') {
-      return '#FFF';
+      return '#F0F1F8';
     } else if (skin === 'bordered' && mode === 'dark') {
       return '#2a1f3d';
     } else if (mode === 'light') {
-      return '#F4F5FA';
+      return '#ECEEF6';
     } else return '#1a1625';
   };
 
@@ -40,10 +40,10 @@ const DefaultPalette = (mode: PaletteMode, skin: Skin, themeColor: ThemeColor) =
       main: mainColor,
       light: lightColor,
       darkBg: '#1a1625',
-      lightBg: '#F4F5FA',
+      lightBg: '#ECEEF6',
       primaryGradient: primaryGradient(),
-      bodyBg: mode === 'light' ? '#F4F5FA' : '#1a1625', // Same as palette.background.default but doesn't consider bordered skin
-      tableHeaderBg: mode === 'light' ? '#F9FAFC' : '#2a1f3d',
+      bodyBg: mode === 'light' ? '#ECEEF6' : '#1a1625', // Same as palette.background.default but doesn't consider bordered skin
+      tableHeaderBg: mode === 'light' ? '#E8EAF4' : '#2a1f3d',
       headerText: '#637381', // Header subtitle text color
     },
     common: {
@@ -116,7 +116,7 @@ const DefaultPalette = (mode: PaletteMode, skin: Skin, themeColor: ThemeColor) =
     },
     divider: `rgba(${mainColor}, 0.12)`,
     background: {
-      paper: mode === 'light' ? '#FFF' : '#2a1f3d',
+      paper: mode === 'light' ? '#F7F8FD' : '#2a1f3d',
       default: defaultBgColor(),
     },
     action: {

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -442,11 +442,15 @@ const ClassroomSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:building' fontSize='0.9rem' style={{ opacity: 0.55, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
+              <Icon icon='tabler:building' fontSize='0.9rem' />
+            </Box>
             <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:books' fontSize='0.85rem' style={{ opacity: 0.45, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.6 }}>
+              <Icon icon='tabler:books' fontSize='0.85rem' />
+            </Box>
             <Typography variant='caption' color='text.secondary'>
               {row.program?.name || 'ไม่ระบุสาขา'} • {row.level?.levelName || 'ไม่ระบุระดับ'}
             </Typography>
@@ -463,19 +467,25 @@ const ClassroomSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:users' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.85 }}>
+              <Icon icon='tabler:users' fontSize='0.9rem' />
+            </Box>
             <Typography variant='body2'>
               นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:user-star' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
+                <Icon icon='tabler:user-star' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>ครู {row._count?.teachers ?? 0}</Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:book' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.7 }}>
+                <Icon icon='tabler:book' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>วิชา {row._count?.course ?? 0}</Typography>
             </Box>
           </Box>

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -31,7 +31,7 @@ import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
 import CustomNoRowsOverlay from '@/@core/components/check-in/CustomNoRowsOverlay';
-import Icon from '@/@core/components/icon';
+import Icon, { ColorIcon } from '@/@core/components/icon';
 import httpClient from '@/@core/utils/http';
 import { authConfig } from '@/configs/auth';
 import {
@@ -442,15 +442,11 @@ const ClassroomSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
-              <Icon icon='tabler:building' fontSize='0.9rem' />
-            </Box>
+            <ColorIcon icon='tabler:building' color='info' fontSize='0.9rem' />
             <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.6 }}>
-              <Icon icon='tabler:books' fontSize='0.85rem' />
-            </Box>
+            <ColorIcon icon='tabler:books' color='info' fontSize='0.85rem' opacity={0.6} />
             <Typography variant='caption' color='text.secondary'>
               {row.program?.name || 'ไม่ระบุสาขา'} • {row.level?.levelName || 'ไม่ระบุระดับ'}
             </Typography>
@@ -467,25 +463,19 @@ const ClassroomSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.85 }}>
-              <Icon icon='tabler:users' fontSize='0.9rem' />
-            </Box>
+            <ColorIcon icon='tabler:users' color='success' fontSize='0.9rem' opacity={0.85} />
             <Typography variant='body2'>
               นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
-                <Icon icon='tabler:user-star' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:user-star' color='primary' fontSize='0.85rem' opacity={0.75} />
               <Typography variant='caption' color='text.secondary'>ครู {row._count?.teachers ?? 0}</Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.7 }}>
-                <Icon icon='tabler:book' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:book' color='info' fontSize='0.85rem' opacity={0.7} />
               <Typography variant='caption' color='text.secondary'>วิชา {row._count?.course ?? 0}</Typography>
             </Box>
           </Box>

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -22,8 +22,9 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { type GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
+import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -150,32 +151,16 @@ const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
   },
 }));
 
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
-  border: 0,
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-columnHeader[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 700,
-    color: theme.palette.text.primary,
-  },
-  '& .MuiDataGrid-row': {
-    transition: 'background-color 180ms ease',
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    },
-  },
-  '& .MuiDataGrid-cell': {
-    display: 'flex',
-    alignItems: 'center',
-    whiteSpace: 'normal',
-    lineHeight: 'unset !important',
-  },
-  '& .MuiDataGrid-footerContainer': {
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    backgroundColor: alpha(theme.palette.background.paper, 0.72),
+  '& .MuiDataGrid-cell[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
 }));
 

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -19,12 +19,14 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
-import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { type GridColDef } from '@mui/x-data-grid';
-import { alpha, styled } from '@mui/material/styles';
-import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { alpha } from '@mui/material/styles';
+import { AppSettingsDataGrid } from '@/@core/components/data-grid/AppListDataGrid';
+import { SectionBox, SectionTitle, SectionDescription } from '@/@core/components/filter-panel';
+import { AppFilterTextField, AppContainedButton } from '@/@core/components/form';
+import { ToolButton, ToolButtonSlot, ToolDivider, ActiveToolButton } from '@/@core/components/toolbar';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -49,147 +51,11 @@ import ClassroomDeleteDialog from '@/components/dialogs/ClassroomDeleteDialog';
 import ClassroomFormDialog from './ClassroomFormDialog';
 import ClassroomPromotionDialog from './ClassroomPromotionDialog';
 
-const PANEL_RADIUS = 16;
-const SECTION_RADIUS = 14;
-const TOOLBAR_RADIUS = 14;
-const CONTROL_RADIUS = 12;
-
 const STATUS_OPTIONS = [
   { value: 'all', label: 'ทุกสถานะ' },
   { value: 'active', label: 'เปิดใช้งาน' },
   { value: 'inactive', label: 'ปิดใช้งาน' },
 ] as const;
-
-const getPanelBorderColor = (theme: any) =>
-  alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1);
-const getPanelShadowColor = (theme: any) =>
-  theme.palette.mode === 'dark' ? alpha(theme.palette.common.black, 0.24) : alpha(theme.palette.primary.main, 0.05);
-const getSurfaceBackground = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
-    : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`;
-const getSectionSurfaceBackground = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.76 : 0.9);
-const getControlSurfaceColor = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.88);
-const getToolbarSurfaceColor = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? alpha(theme.palette.background.paper, 0.04)
-    : alpha(theme.palette.background.paper, 0.98);
-
-const SectionSurface = styled(Box)(({ theme }) => ({
-  borderRadius: SECTION_RADIUS,
-  border: `1px solid ${getPanelBorderColor(theme)}`,
-  backgroundColor: getSectionSurfaceBackground(theme),
-  boxShadow:
-    theme.palette.mode === 'dark'
-      ? `inset 0 1px 0 ${alpha(theme.palette.common.white, 0.03)}`
-      : `0 10px 22px ${alpha(theme.palette.primary.main, 0.03)}`,
-}));
-
-const SectionTitle = styled(Typography)(({ theme }) => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  fontSize: 'clamp(0.92rem, 0.88rem + 0.14vw, 1rem)',
-  fontWeight: 800,
-  letterSpacing: '-0.01em',
-  color: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.88 : 0.82),
-  '&::before': {
-    content: '""',
-    width: 10,
-    height: 10,
-    borderRadius: 999,
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.72 : 0.64),
-    boxShadow:
-      theme.palette.mode === 'dark'
-        ? `0 0 0 6px ${alpha(theme.palette.primary.main, 0.08)}`
-        : `0 0 0 5px ${alpha(theme.palette.primary.main, 0.08)}`,
-  },
-}));
-
-const SectionDescription = styled(Typography)(({ theme }) => ({
-  marginTop: theme.spacing(0.5),
-  maxWidth: '60ch',
-  fontSize: 'clamp(0.94rem, 0.9rem + 0.16vw, 1rem)',
-  fontWeight: 500,
-  lineHeight: 1.6,
-  color: theme.palette.mode === 'dark' ? alpha(theme.palette.text.primary, 0.8) : theme.palette.text.secondary,
-}));
-
-const ToolButton = styled(IconButton)(({ theme }) => ({
-  width: '100%',
-  minWidth: 54,
-  height: 52,
-  borderRadius: 0,
-  border: 0,
-  backgroundColor: 'transparent',
-  color: theme.palette.primary.main,
-  boxShadow: 'none',
-  transition: 'background-color 180ms ease, color 180ms ease',
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.08),
-  },
-}));
-
-const ToolButtonSlot = styled(Box)({
-  display: 'flex',
-  flex: '1 1 0',
-  minWidth: 0,
-});
-
-const ToolDivider = styled(Box)(({ theme }) => ({
-  width: 1,
-  alignSelf: 'stretch',
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.16),
-}));
-
-const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-  },
-}));
-
-const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
-  '& .MuiDataGrid-columnHeader[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-}));
-
-const CONTROL_SX = {
-  '& .MuiOutlinedInput-root': {
-    borderRadius: `${CONTROL_RADIUS}px`,
-    backgroundColor: (theme: any) => getControlSurfaceColor(theme),
-    '& fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-    },
-    '&:hover fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.primary.main, 0.28),
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: 'primary.main',
-    },
-  },
-  '& .MuiInputBase-input': {
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-root': {
-    fontSize: '0.92rem',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-shrink': {
-    fontSize: '0.86rem',
-  },
-} as const;
 
 const getErrorMessage = (error: any, fallback: string) => {
   if (typeof error?.response?.data?.message === 'string') {
@@ -702,10 +568,16 @@ const ClassroomSettingsPage = () => {
         <Grid size={12}>
           <Card
             sx={{
-              borderRadius: `${PANEL_RADIUS}px`,
-              border: (theme) => `1px solid ${getPanelBorderColor(theme)}`,
-              background: (theme) => getSurfaceBackground(theme),
-              boxShadow: (theme) => `0 22px 44px ${getPanelShadowColor(theme)}`,
+              borderRadius: 6,
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1)}`,
+              background: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
+                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`,
+              boxShadow: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `0 22px 44px ${alpha(theme.palette.common.black, 0.24)}`
+                  : `0 22px 44px ${alpha(theme.palette.primary.main, 0.05)}`,
             }}
           >
             <CardHeader
@@ -755,7 +627,7 @@ const ClassroomSettingsPage = () => {
             />
 
             <CardContent sx={{ px: { xs: 4, sm: 5, md: 6 }, pt: 2, pb: { xs: 4, sm: 5 } }}>
-              <SectionSurface sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
+              <SectionBox sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
                 <Grid container spacing={3} sx={{ alignItems: 'flex-end' }}>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <SectionTitle>ค้นหาและกรอง</SectionTitle>
@@ -776,8 +648,11 @@ const ClassroomSettingsPage = () => {
                           display: 'inline-flex',
                           alignItems: 'stretch',
                           overflow: 'hidden',
-                          borderRadius: TOOLBAR_RADIUS,
-                          bgcolor: (theme) => getToolbarSurfaceColor(theme),
+                          borderRadius: 14,
+                          bgcolor: (theme) =>
+                            theme.palette.mode === 'dark'
+                              ? alpha(theme.palette.background.paper, 0.04)
+                              : alpha(theme.palette.background.paper, 0.98),
                           border: (theme) =>
                             `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.18)}`,
                           boxShadow: (theme) =>
@@ -858,18 +733,17 @@ const ClassroomSettingsPage = () => {
                     </Box>
                   </Grid>
                   <Grid size={{ xs: 12, md: 4 }}>
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-search'
                       fullWidth
                       label='ค้นหาห้องเรียน'
                       placeholder='พิมพ์ชื่อห้องเรียน รหัส หรือคำอธิบาย'
                       value={searchText}
                       onChange={(event) => setSearchText(event.target.value)}
-                      sx={CONTROL_SX}
                     />
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6, md: 2 }}>
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-department-filter'
                       select
                       fullWidth
@@ -880,7 +754,6 @@ const ClassroomSettingsPage = () => {
                         setDepartmentFilter(nextDepartment);
                         setProgramFilter('all');
                       }}
-                      sx={CONTROL_SX}
                     >
                       <MenuItem value='all'>ทุกแผนก</MenuItem>
                       {departments.map((department) => (
@@ -888,17 +761,16 @@ const ClassroomSettingsPage = () => {
                           {department.name}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6, md: 2 }}>
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-program-filter'
                       select
                       fullWidth
                       label='สาขา'
                       value={programFilter}
                       onChange={(event) => setProgramFilter(event.target.value)}
-                      sx={CONTROL_SX}
                     >
                       <MenuItem value='all'>ทุกสาขา</MenuItem>
                       {availablePrograms.map((program) => (
@@ -906,17 +778,16 @@ const ClassroomSettingsPage = () => {
                           {program.name}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6, md: 2 }}>
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-level-filter'
                       select
                       fullWidth
                       label='ระดับชั้น'
                       value={levelFilter}
                       onChange={(event) => setLevelFilter(event.target.value)}
-                      sx={CONTROL_SX}
                     >
                       <MenuItem value='all'>ทุกระดับ</MenuItem>
                       {levels.map((level) => (
@@ -924,27 +795,26 @@ const ClassroomSettingsPage = () => {
                           {level.levelName}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6, md: 2 }}>
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-status-filter'
                       select
                       fullWidth
                       label='สถานะ'
                       value={statusFilter}
                       onChange={(event) => setStatusFilter(event.target.value as 'all' | 'active' | 'inactive')}
-                      sx={CONTROL_SX}
                     >
                       {STATUS_OPTIONS.map((option) => (
                         <MenuItem key={option.value} value={option.value}>
                           {option.label}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                 </Grid>
-              </SectionSurface>
+              </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
                 {[
@@ -974,7 +844,7 @@ const ClassroomSettingsPage = () => {
                   },
                 ].map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
-                    <SectionSurface sx={{ p: 3, height: '100%' }}>
+                    <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
                         <Avatar
                           variant='rounded'
@@ -1003,12 +873,12 @@ const ClassroomSettingsPage = () => {
                       }}>
                         {item.hint}
                       </Typography>
-                    </SectionSurface>
+                    </SectionBox>
                   </Grid>
                 ))}
               </Grid>
 
-              <SectionSurface sx={{ p: { xs: 2, sm: 2.5 } }}>
+              <SectionBox sx={{ p: { xs: 2, sm: 2.5 } }}>
                 <Box
                   sx={{
                     px: { xs: 1, sm: 1.5 },
@@ -1030,7 +900,7 @@ const ClassroomSettingsPage = () => {
                 </Box>
 
                 <Box sx={{ width: '100%' }}>
-                  <StyledDataGrid
+                  <AppSettingsDataGrid
                     autoHeight
                     rows={filteredClassrooms}
                     columns={columns}
@@ -1050,7 +920,7 @@ const ClassroomSettingsPage = () => {
                     pageSizeOptions={[10, 25, 50]}
                   />
                 </Box>
-              </SectionSurface>
+              </SectionBox>
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/classroom/ClassroomSettingsPage.tsx
@@ -411,15 +411,25 @@ const ClassroomSettingsPage = () => {
           >
             {row.name || '-'}
           </Typography>
-          <Typography
-            variant='caption'
+          <Box
+            component='span'
             sx={{
-              color: 'text.secondary',
-              display: 'block',
-              mt: 0.25
-            }}>
-            {row.classroomId || 'ยังไม่กำหนดรหัสห้องเรียน'}
-          </Typography>
+              display: 'inline-block',
+              mt: 0.5,
+              px: 0.75,
+              py: 0.1,
+              borderRadius: 1,
+              fontSize: '0.72rem',
+              fontFamily: 'monospace',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+              color: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.9 : 0.75),
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+            }}
+          >
+            {row.classroomId || '—'}
+          </Box>
         </Box>
       ),
     },
@@ -430,17 +440,17 @@ const ClassroomSettingsPage = () => {
       minWidth: 220,
       sortable: false,
       renderCell: ({ row }) => (
-        <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
-          <Typography
-            variant='caption'
-            sx={{
-              color: 'text.secondary',
-              display: 'block',
-              mt: 0.25
-            }}>
-            {row.program?.name || 'ไม่ระบุสาขา'} • {row.level?.levelName || 'ไม่ระบุระดับ'}
-          </Typography>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:building' fontSize='0.9rem' style={{ opacity: 0.55, flexShrink: 0 }} />
+            <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:books' fontSize='0.85rem' style={{ opacity: 0.45, flexShrink: 0 }} />
+            <Typography variant='caption' color='text.secondary'>
+              {row.program?.name || 'ไม่ระบุสาขา'} • {row.level?.levelName || 'ไม่ระบุระดับ'}
+            </Typography>
+          </Box>
         </Box>
       ),
     },
@@ -451,13 +461,24 @@ const ClassroomSettingsPage = () => {
       minWidth: 190,
       sortable: false,
       renderCell: ({ row }) => (
-        <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2'>นักเรียน {row._count?.student ?? 0} คน</Typography>
-          <Typography variant='caption' sx={{
-            color: 'text.secondary'
-          }}>
-            ครู {row._count?.teachers ?? 0} • รายวิชา {row._count?.course ?? 0}
-          </Typography>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:users' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Typography variant='body2'>
+              นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:user-star' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>ครู {row._count?.teachers ?? 0}</Typography>
+            </Box>
+            <Typography variant='caption' color='text.disabled'>·</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:book' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>วิชา {row._count?.course ?? 0}</Typography>
+            </Box>
+          </Box>
         </Box>
       ),
     },
@@ -488,19 +509,14 @@ const ClassroomSettingsPage = () => {
         const formatted = formatThaiDateTimeParts(row.updatedAt);
 
         return (
-          <Box sx={{ py: 1.5 }}>
-            <Typography variant='body2' sx={{
-              color: 'text.secondary'
-            }}>
-              {formatted.date}
-            </Typography>
-            {formatted.time ? (
-              <Typography variant='caption' sx={{
-                color: 'text.secondary'
-              }}>
-                {formatted.time}
-              </Typography>
-            ) : null}
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75, py: 0.5 }}>
+            <Icon icon='tabler:calendar-event' fontSize='0.95rem' style={{ opacity: 0.45, flexShrink: 0, marginTop: 2 }} />
+            <Box>
+              <Typography variant='body2' color='text.secondary'>{formatted.date}</Typography>
+              {formatted.time ? (
+                <Typography variant='caption' color='text.secondary'>{formatted.time}</Typography>
+              ) : null}
+            </Box>
           </Box>
         );
       },
@@ -817,32 +833,14 @@ const ClassroomSettingsPage = () => {
               </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
-                {[
-                  {
-                    label: 'ห้องเรียนทั้งหมด',
-                    value: summary.total,
-                    hint: `${summary.active} เปิดใช้งาน`,
-                    icon: 'tabler:door',
-                  },
-                  {
-                    label: 'ปิดใช้งาน',
-                    value: summary.inactive,
-                    hint: 'พักใช้งานชั่วคราว',
-                    icon: 'tabler:door-off',
-                  },
-                  {
-                    label: 'นักเรียนที่ผูกอยู่',
-                    value: summary.students,
-                    hint: 'รวมทั้งระบบ',
-                    icon: 'tabler:users',
-                  },
-                  {
-                    label: 'ครูที่ผูกอยู่',
-                    value: summary.teachers,
-                    hint: 'พร้อมใช้งานต่อในระบบ',
-                    icon: 'tabler:user-star',
-                  },
-                ].map((item) => (
+                {(
+                  [
+                    { label: 'ห้องเรียนทั้งหมด', value: summary.total, hint: `${summary.active} เปิดใช้งาน`, icon: 'tabler:door', colorKey: 'primary' },
+                    { label: 'ปิดใช้งาน', value: summary.inactive, hint: 'พักใช้งานชั่วคราว', icon: 'tabler:door-off', colorKey: 'warning' },
+                    { label: 'นักเรียนที่ผูกอยู่', value: summary.students, hint: 'รวมทั้งระบบ', icon: 'tabler:users', colorKey: 'info' },
+                    { label: 'ครูที่ผูกอยู่', value: summary.teachers, hint: 'พร้อมใช้งานต่อในระบบ', icon: 'tabler:user-star', colorKey: 'success' },
+                  ] as Array<{ label: string; value: number; hint: string; icon: string; colorKey: 'primary' | 'warning' | 'info' | 'success' }>
+                ).map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
                     <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
@@ -853,24 +851,20 @@ const ClassroomSettingsPage = () => {
                             height: 40,
                             borderRadius: 2.5,
                             bgcolor: (theme) =>
-                              alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
-                            color: 'primary.main',
+                              alpha(theme.palette[item.colorKey].main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
+                            color: `${item.colorKey}.main`,
                           }}
                         >
                           <Icon icon={item.icon} fontSize='1.2rem' />
                         </Avatar>
-                        <Typography variant='body2' sx={{
-                          color: 'text.secondary'
-                        }}>
+                        <Typography variant='body2' color='text.secondary'>
                           {item.label}
                         </Typography>
                       </Box>
                       <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.03em' }}>
                         {item.value}
                       </Typography>
-                      <Typography variant='caption' sx={{
-                        color: 'text.secondary'
-                      }}>
+                      <Typography variant='caption' color='text.secondary'>
                         {item.hint}
                       </Typography>
                     </SectionBox>

--- a/frontend/src/views/apps/settings/classroom/TableHeader.tsx
+++ b/frontend/src/views/apps/settings/classroom/TableHeader.tsx
@@ -1,7 +1,13 @@
-import { Box, Button, IconButton, InputAdornment, TextField } from '@mui/material';
-import { useEffect, useState } from 'react';
+'use client';
 
 import IconifyIcon from '@/@core/components/icon';
+import { SectionBox } from '@/@core/components/filter-panel';
+import { AppSearchTextField, AppContainedButton } from '@/@core/components/form';
+import Box from '@mui/material/Box';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import { useEffect, useState } from 'react';
 
 interface TableHeaderProps {
   value: string;
@@ -23,57 +29,61 @@ const TableHeader = ({ handleFilter, toggle, value }: TableHeaderProps) => {
   };
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        gap: 2,
-        px: { xs: 4, sm: 5 },
-        py: { xs: 3, sm: 3.5 },
-        borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-      }}
-    >
-      <TextField
-        id='classroom-search'
-        size='small'
-        value={keyword}
-        placeholder='ค้นชื่อห้องเรียน'
-        onChange={handleOnChange}
-        slotProps={{
-          input: {
-            endAdornment: (
-              <InputAdornment position='end'>
-                {keyword && (
-                  <IconButton
-                    size='small'
-                    onClick={() => {
-                      setKeyword('');
-                      handleFilter('');
-                    }}
-                  >
-                    <IconifyIcon icon='uil:times' width={18} height={18} />
-                  </IconButton>
-                )}
-              </InputAdornment>
-            ),
-          },
-        }}
-        sx={{ width: { xs: '100%', sm: 260 } }}
-      />
-
-      <Box sx={{ ml: { sm: 'auto' }, width: { xs: '100%', sm: 'auto' } }}>
-        <Button
-          id='add-new-record-classroom'
-          fullWidth
-          variant='contained'
-          disableElevation
-          startIcon={<IconifyIcon icon='ci:house-add' width={18} height={18} />}
-          onClick={toggle}
+    <Box sx={{ px: { xs: 3, sm: 4, lg: 5 }, pb: { xs: 3, sm: 4 } }}>
+      <SectionBox id='classroom-list-toolbar-surface'>
+        <Stack
+          id='classroom-list-toolbar-row'
+          direction={{ xs: 'column', sm: 'row' }}
+          sx={{
+            alignItems: { xs: 'stretch', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: { xs: 1.75, sm: 2 },
+          }}
         >
-          เพิ่มรายชื่อห้องเรียน
-        </Button>
-      </Box>
+          <AppSearchTextField
+            id='classroom-search-input'
+            size='small'
+            value={keyword}
+            placeholder='ค้นชื่อห้องเรียน'
+            onChange={handleOnChange}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position='start'>
+                    <IconifyIcon icon='tabler:search' fontSize='1.1rem' />
+                  </InputAdornment>
+                ),
+                endAdornment: keyword ? (
+                  <InputAdornment position='end'>
+                    <IconButton
+                      id='clear-classroom-search-button'
+                      size='small'
+                      onClick={() => {
+                        setKeyword('');
+                        handleFilter('');
+                      }}
+                    >
+                      <IconifyIcon icon='uil:times' width={18} height={18} />
+                    </IconButton>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+            sx={{ width: { xs: '100%', md: 320 }, flex: { xs: '1 1 auto', md: '0 1 320px' } }}
+          />
+
+          <AppContainedButton
+            id='add-classroom-button'
+            variant='contained'
+            disableElevation
+            startIcon={<IconifyIcon icon='ci:house-add' width={18} height={18} />}
+            onClick={toggle}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
+          >
+            เพิ่มรายชื่อห้องเรียน
+          </AppContainedButton>
+        </Stack>
+      </SectionBox>
     </Box>
   );
 };

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -679,32 +679,14 @@ const DepartmentSettingsPage = () => {
               </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
-                {[
-                  {
-                    label: 'แผนกทั้งหมด',
-                    value: summary.total,
-                    hint: `${summary.active} เปิดใช้งาน`,
-                    icon: 'tabler:building-community',
-                  },
-                  {
-                    label: 'ปิดใช้งาน',
-                    value: summary.inactive,
-                    hint: 'รอตรวจสอบหรือพักใช้งาน',
-                    icon: 'tabler:building-off',
-                  },
-                  {
-                    label: 'สาขาที่ผูกอยู่',
-                    value: summary.programs,
-                    hint: 'รวมทั้งระบบ',
-                    icon: 'tabler:school',
-                  },
-                  {
-                    label: 'ห้องเรียนที่ผูกอยู่',
-                    value: summary.classrooms,
-                    hint: 'พร้อมใช้งานต่อในระบบ',
-                    icon: 'tabler:door',
-                  },
-                ].map((item) => (
+                {(
+                  [
+                    { label: 'แผนกทั้งหมด', value: summary.total, hint: `${summary.active} เปิดใช้งาน`, icon: 'tabler:building-community', colorKey: 'primary' },
+                    { label: 'ปิดใช้งาน', value: summary.inactive, hint: 'รอตรวจสอบหรือพักใช้งาน', icon: 'tabler:building-off', colorKey: 'warning' },
+                    { label: 'สาขาที่ผูกอยู่', value: summary.programs, hint: 'รวมทั้งระบบ', icon: 'tabler:school', colorKey: 'info' },
+                    { label: 'ห้องเรียนที่ผูกอยู่', value: summary.classrooms, hint: 'พร้อมใช้งานต่อในระบบ', icon: 'tabler:door', colorKey: 'success' },
+                  ] as Array<{ label: string; value: number; hint: string; icon: string; colorKey: 'primary' | 'warning' | 'info' | 'success' }>
+                ).map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
                     <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
@@ -715,8 +697,8 @@ const DepartmentSettingsPage = () => {
                             height: 40,
                             borderRadius: 2.5,
                             bgcolor: (theme) =>
-                              alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
-                            color: 'primary.main',
+                              alpha(theme.palette[item.colorKey].main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
+                            color: `${item.colorKey}.main`,
                           }}
                         >
                           <Icon icon={item.icon} fontSize='1.2rem' />

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -1,32 +1,32 @@
 'use client';
 
-import {
-  Alert,
-  AlertTitle,
-  Avatar,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  List,
-  ListItem,
-  ListItemText,
-  MenuItem,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import { type GridColDef } from '@mui/x-data-grid';
-import { alpha, styled } from '@mui/material/styles';
-import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { alpha } from '@mui/material/styles';
+import { AppSettingsDataGrid } from '@/@core/components/data-grid/AppListDataGrid';
+import { SectionBox, SectionTitle, SectionDescription } from '@/@core/components/filter-panel';
+import { AppFilterTextField, AppContainedButton } from '@/@core/components/form';
+import { ToolButton, ToolButtonSlot, ToolDivider, ActiveToolButton } from '@/@core/components/toolbar';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -48,147 +48,11 @@ import {
 import DepartmentDeleteDialog from '@/components/dialogs/DepartmentDeleteDialog';
 import DepartmentFormDialog from './DepartmentFormDialog';
 
-const PANEL_RADIUS = 16;
-const SECTION_RADIUS = 14;
-const TOOLBAR_RADIUS = 14;
-const CONTROL_RADIUS = 12;
-
 const STATUS_OPTIONS = [
   { value: 'all', label: 'ทุกสถานะ' },
   { value: 'active', label: 'เปิดใช้งาน' },
   { value: 'inactive', label: 'ปิดใช้งาน' },
 ] as const;
-
-const getPanelBorderColor = (theme: any) =>
-  alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1);
-const getPanelShadowColor = (theme: any) =>
-  theme.palette.mode === 'dark' ? alpha(theme.palette.common.black, 0.24) : alpha(theme.palette.primary.main, 0.05);
-const getSurfaceBackground = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
-    : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`;
-const getSectionSurfaceBackground = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.76 : 0.9);
-const getControlSurfaceColor = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.88);
-const getToolbarSurfaceColor = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? alpha(theme.palette.background.paper, 0.04)
-    : alpha(theme.palette.background.paper, 0.98);
-
-const SectionSurface = styled(Box)(({ theme }) => ({
-  borderRadius: SECTION_RADIUS,
-  border: `1px solid ${getPanelBorderColor(theme)}`,
-  backgroundColor: getSectionSurfaceBackground(theme),
-  boxShadow:
-    theme.palette.mode === 'dark'
-      ? `inset 0 1px 0 ${alpha(theme.palette.common.white, 0.03)}`
-      : `0 10px 22px ${alpha(theme.palette.primary.main, 0.03)}`,
-}));
-
-const SectionTitle = styled(Typography)(({ theme }) => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  fontSize: 'clamp(0.92rem, 0.88rem + 0.14vw, 1rem)',
-  fontWeight: 800,
-  letterSpacing: '-0.01em',
-  color: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.88 : 0.82),
-  '&::before': {
-    content: '""',
-    width: 10,
-    height: 10,
-    borderRadius: 999,
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.72 : 0.64),
-    boxShadow:
-      theme.palette.mode === 'dark'
-        ? `0 0 0 6px ${alpha(theme.palette.primary.main, 0.08)}`
-        : `0 0 0 5px ${alpha(theme.palette.primary.main, 0.08)}`,
-  },
-}));
-
-const SectionDescription = styled(Typography)(({ theme }) => ({
-  marginTop: theme.spacing(0.5),
-  maxWidth: '60ch',
-  fontSize: 'clamp(0.94rem, 0.9rem + 0.16vw, 1rem)',
-  fontWeight: 500,
-  lineHeight: 1.6,
-  color: theme.palette.mode === 'dark' ? alpha(theme.palette.text.primary, 0.8) : theme.palette.text.secondary,
-}));
-
-const ToolButton = styled(IconButton)(({ theme }) => ({
-  width: '100%',
-  minWidth: 54,
-  height: 52,
-  borderRadius: 0,
-  border: 0,
-  backgroundColor: 'transparent',
-  color: theme.palette.primary.main,
-  boxShadow: 'none',
-  transition: 'background-color 180ms ease, color 180ms ease',
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.08),
-  },
-}));
-
-const ToolButtonSlot = styled(Box)({
-  display: 'flex',
-  flex: '1 1 0',
-  minWidth: 0,
-});
-
-const ToolDivider = styled(Box)(({ theme }) => ({
-  width: 1,
-  alignSelf: 'stretch',
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.16),
-}));
-
-const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-  },
-}));
-
-const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
-  '& .MuiDataGrid-columnHeader[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-}));
-
-const CONTROL_SX = {
-  '& .MuiOutlinedInput-root': {
-    borderRadius: `${CONTROL_RADIUS}px`,
-    backgroundColor: (theme: any) => getControlSurfaceColor(theme),
-    '& fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-    },
-    '&:hover fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.primary.main, 0.28),
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: 'primary.main',
-    },
-  },
-  '& .MuiInputBase-input': {
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-root': {
-    fontSize: '0.92rem',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-shrink': {
-    fontSize: '0.86rem',
-  },
-} as const;
 
 const getErrorMessage = (error: any, fallback: string) => {
   if (typeof error?.response?.data?.message === 'string') {
@@ -598,10 +462,16 @@ const DepartmentSettingsPage = () => {
         <Grid size={12}>
           <Card
             sx={{
-              borderRadius: `${PANEL_RADIUS}px`,
-              border: (theme) => `1px solid ${getPanelBorderColor(theme)}`,
-              background: (theme) => getSurfaceBackground(theme),
-              boxShadow: (theme) => `0 22px 44px ${getPanelShadowColor(theme)}`,
+              borderRadius: 6,
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1)}`,
+              background: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
+                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`,
+              boxShadow: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `0 22px 44px ${alpha(theme.palette.common.black, 0.24)}`
+                  : `0 22px 44px ${alpha(theme.palette.primary.main, 0.05)}`,
             }}
           >
             <CardHeader
@@ -646,7 +516,7 @@ const DepartmentSettingsPage = () => {
             />
 
             <CardContent sx={{ px: { xs: 4, sm: 5, md: 6 }, pt: 2, pb: { xs: 4, sm: 5 } }}>
-              <SectionSurface sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
+              <SectionBox sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
                 <Grid container spacing={3} sx={{ alignItems: 'flex-end' }}>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <SectionTitle>ค้นหาและกรอง</SectionTitle>
@@ -665,8 +535,11 @@ const DepartmentSettingsPage = () => {
                           display: 'inline-flex',
                           alignItems: 'stretch',
                           overflow: 'hidden',
-                          borderRadius: TOOLBAR_RADIUS,
-                          bgcolor: (theme) => getToolbarSurfaceColor(theme),
+                          borderRadius: 14,
+                          bgcolor: (theme) =>
+                            theme.palette.mode === 'dark'
+                              ? alpha(theme.palette.background.paper, 0.04)
+                              : alpha(theme.palette.background.paper, 0.98),
                           border: (theme) =>
                             `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.18)}`,
                           boxShadow: (theme) =>
@@ -733,33 +606,31 @@ const DepartmentSettingsPage = () => {
                     </Box>
                   </Grid>
                   <Grid size={{ xs: 12, md: 8 }}>
-                    <TextField
+                    <AppFilterTextField
                       fullWidth
                       label='ค้นหาแผนก'
                       placeholder='พิมพ์ชื่อแผนก รหัสแผนก หรือคำอธิบาย'
                       value={searchText}
                       onChange={(event) => setSearchText(event.target.value)}
-                      sx={CONTROL_SX}
                     />
                   </Grid>
                   <Grid size={{ xs: 12, md: 4 }}>
-                    <TextField
+                    <AppFilterTextField
                       select
                       fullWidth
                       label='สถานะ'
                       value={statusFilter}
                       onChange={(event) => setStatusFilter(event.target.value as 'all' | 'active' | 'inactive')}
-                      sx={CONTROL_SX}
                     >
                       {STATUS_OPTIONS.map((option) => (
                         <MenuItem key={option.value} value={option.value}>
                           {option.label}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                 </Grid>
-              </SectionSurface>
+              </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
                 {[
@@ -789,7 +660,7 @@ const DepartmentSettingsPage = () => {
                   },
                 ].map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
-                    <SectionSurface sx={{ p: 3, height: '100%' }}>
+                    <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
                         <Avatar
                           variant='rounded'
@@ -814,12 +685,12 @@ const DepartmentSettingsPage = () => {
                       <Typography variant='caption' color='text.secondary'>
                         {item.hint}
                       </Typography>
-                    </SectionSurface>
+                    </SectionBox>
                   </Grid>
                 ))}
               </Grid>
 
-              <SectionSurface sx={{ p: { xs: 2, sm: 2.5 } }}>
+              <SectionBox sx={{ p: { xs: 2, sm: 2.5 } }}>
                 <Box
                   sx={{
                     px: { xs: 1, sm: 1.5 },
@@ -841,7 +712,7 @@ const DepartmentSettingsPage = () => {
                 </Box>
 
                 <Box sx={{ width: '100%' }}>
-                  <StyledDataGrid
+                  <AppSettingsDataGrid
                     autoHeight
                     rows={filteredDepartments}
                     columns={columns}
@@ -860,7 +731,7 @@ const DepartmentSettingsPage = () => {
                     pageSizeOptions={[10, 25, 50]}
                   />
                 </Box>
-              </SectionSurface>
+              </SectionBox>
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -717,6 +717,7 @@ const DepartmentSettingsPage = () => {
                     rows={filteredDepartments}
                     columns={columns}
                     loading={isLoading}
+                    getRowHeight={() => 'auto'}
                     disableRowSelectionOnClick
                     disableColumnMenu
                     hideFooterSelectedRowCount

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -386,21 +386,27 @@ const DepartmentSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.6 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:books' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
+              <Icon icon='tabler:books' fontSize='0.9rem' />
+            </Box>
             <Typography variant='body2'>
               สาขา <strong>{row._count?.program ?? 0}</strong> รายการ
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:door' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'warning.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
+                <Icon icon='tabler:door' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>
                 {row._count?.classroom ?? 0} ห้อง
               </Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:users' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
+                <Icon icon='tabler:users' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>
                 {row._count?.student ?? 0} คน
               </Typography>

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -32,7 +32,7 @@ import { toast } from 'react-toastify';
 
 import httpClient from '@/@core/utils/http';
 import CustomNoRowsOverlay from '@/@core/components/check-in/CustomNoRowsOverlay';
-import Icon from '@/@core/components/icon';
+import Icon, { ColorIcon } from '@/@core/components/icon';
 import { authConfig } from '@/configs/auth';
 import {
   useCreateDepartment,
@@ -386,27 +386,21 @@ const DepartmentSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.6 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
-              <Icon icon='tabler:books' fontSize='0.9rem' />
-            </Box>
+            <ColorIcon icon='tabler:books' color='info' fontSize='0.9rem' />
             <Typography variant='body2'>
               สาขา <strong>{row._count?.program ?? 0}</strong> รายการ
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'warning.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
-                <Icon icon='tabler:door' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:door' color='warning' fontSize='0.85rem' opacity={0.75} />
               <Typography variant='caption' color='text.secondary'>
                 {row._count?.classroom ?? 0} ห้อง
               </Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
-                <Icon icon='tabler:users' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:users' color='success' fontSize='0.85rem' />
               <Typography variant='caption' color='text.secondary'>
                 {row._count?.student ?? 0} คน
               </Typography>

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -24,8 +24,9 @@ import {
   Typography,
 } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { type GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
+import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -149,32 +150,16 @@ const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
   },
 }));
 
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
-  border: 0,
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-columnHeader[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 700,
-    color: theme.palette.text.primary,
-  },
-  '& .MuiDataGrid-row': {
-    transition: 'background-color 180ms ease',
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    },
-  },
-  '& .MuiDataGrid-cell': {
-    display: 'flex',
-    alignItems: 'center',
-    whiteSpace: 'normal',
-    lineHeight: 'unset !important',
-  },
-  '& .MuiDataGrid-footerContainer': {
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    backgroundColor: alpha(theme.palette.background.paper, 0.72),
+  '& .MuiDataGrid-cell[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
 }));
 

--- a/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/department/DepartmentSettingsPage.tsx
@@ -322,12 +322,28 @@ const DepartmentSettingsPage = () => {
       minWidth: 260,
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2' sx={{ fontWeight: 700, fontSize: '0.98rem' }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, fontSize: '0.98rem', lineHeight: 1.4 }}>
             {row.name || '-'}
           </Typography>
-          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 0.25 }}>
-            {row.departmentId || 'ยังไม่กำหนดรหัสแผนก'}
-          </Typography>
+          <Box
+            component='span'
+            sx={{
+              display: 'inline-block',
+              mt: 0.5,
+              px: 0.75,
+              py: 0.1,
+              borderRadius: 1,
+              fontSize: '0.72rem',
+              fontFamily: 'monospace',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+              color: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.9 : 0.75),
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+            }}
+          >
+            {row.departmentId || '—'}
+          </Box>
         </Box>
       ),
     },
@@ -337,18 +353,28 @@ const DepartmentSettingsPage = () => {
       flex: 0.28,
       minWidth: 220,
       renderCell: ({ row }) => (
-        <Typography
-          variant='body2'
-          color='text.secondary'
-          sx={{
-            display: '-webkit-box',
-            overflow: 'hidden',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-          }}
-        >
-          {row.description || 'ยังไม่มีคำอธิบาย'}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75, py: 0.5 }}>
+          <Icon
+            icon='tabler:info-circle'
+            fontSize='0.95rem'
+            style={{ marginTop: 2, flexShrink: 0, opacity: 0.45 }}
+          />
+          <Typography
+            variant='body2'
+            color='text.secondary'
+            sx={{
+              display: '-webkit-box',
+              overflow: 'hidden',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              lineHeight: 1.5,
+              fontStyle: row.description ? 'normal' : 'italic',
+              opacity: row.description ? 1 : 0.55,
+            }}
+          >
+            {row.description || 'ยังไม่มีคำอธิบาย'}
+          </Typography>
+        </Box>
       ),
     },
     {
@@ -358,11 +384,28 @@ const DepartmentSettingsPage = () => {
       minWidth: 190,
       sortable: false,
       renderCell: ({ row }) => (
-        <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2'>สาขา {row._count?.program ?? 0} รายการ</Typography>
-          <Typography variant='caption' color='text.secondary'>
-            ห้องเรียน {row._count?.classroom ?? 0} • นักเรียน {row._count?.student ?? 0}
-          </Typography>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.6 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:books' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Typography variant='body2'>
+              สาขา <strong>{row._count?.program ?? 0}</strong> รายการ
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:door' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>
+                {row._count?.classroom ?? 0} ห้อง
+              </Typography>
+            </Box>
+            <Typography variant='caption' color='text.disabled'>·</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:users' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>
+                {row._count?.student ?? 0} คน
+              </Typography>
+            </Box>
+          </Box>
         </Box>
       ),
     },
@@ -388,11 +431,14 @@ const DepartmentSettingsPage = () => {
       field: 'updatedAt',
       headerName: 'อัปเดตล่าสุด',
       flex: 0.18,
-      minWidth: 180,
+      minWidth: 170,
       renderCell: ({ row }) => (
-        <Typography variant='body2' color='text.secondary'>
-          {formatThaiDateTime(row.updatedAt)}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Icon icon='tabler:calendar-event' fontSize='0.95rem' style={{ opacity: 0.45, flexShrink: 0 }} />
+          <Typography variant='body2' color='text.secondary'>
+            {formatThaiDateTime(row.updatedAt)}
+          </Typography>
+        </Box>
       ),
     },
     {

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -377,11 +377,15 @@ const ProgramSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:building' fontSize='0.9rem' style={{ opacity: 0.55, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
+              <Icon icon='tabler:building' fontSize='0.9rem' />
+            </Box>
             <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:school' fontSize='0.85rem' style={{ opacity: 0.45, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.65 }}>
+              <Icon icon='tabler:school' fontSize='0.85rem' />
+            </Box>
             <Typography variant='caption' color='text.secondary'>
               {row.level?.levelName || 'ไม่ระบุระดับชั้น'}
             </Typography>
@@ -398,19 +402,25 @@ const ProgramSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Icon icon='tabler:users' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.85 }}>
+              <Icon icon='tabler:users' fontSize='0.9rem' />
+            </Box>
             <Typography variant='body2'>
               นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:door' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'warning.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
+                <Icon icon='tabler:door' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>ห้อง {row._count?.classroom ?? 0}</Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Icon icon='tabler:user-star' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
+                <Icon icon='tabler:user-star' fontSize='0.85rem' />
+              </Box>
               <Typography variant='caption' color='text.secondary'>ครู {row._count?.teacher ?? 0}</Typography>
             </Box>
           </Box>

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -1,32 +1,32 @@
 'use client';
 
-import {
-  Alert,
-  AlertTitle,
-  Avatar,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  List,
-  ListItem,
-  ListItemText,
-  MenuItem,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import { type GridColDef } from '@mui/x-data-grid';
-import { alpha, styled } from '@mui/material/styles';
-import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { alpha } from '@mui/material/styles';
+import { AppSettingsDataGrid } from '@/@core/components/data-grid/AppListDataGrid';
+import { SectionBox, SectionTitle, SectionDescription } from '@/@core/components/filter-panel';
+import { AppFilterTextField, AppContainedButton } from '@/@core/components/form';
+import { ToolButton, ToolButtonSlot, ToolDivider, ActiveToolButton } from '@/@core/components/toolbar';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -50,147 +50,11 @@ import {
 import ProgramDeleteDialog from '@/components/dialogs/ProgramDeleteDialog';
 import ProgramFormDialog from './ProgramFormDialog';
 
-const PANEL_RADIUS = 16;
-const SECTION_RADIUS = 14;
-const TOOLBAR_RADIUS = 14;
-const CONTROL_RADIUS = 12;
-
 const STATUS_OPTIONS = [
   { value: 'all', label: 'ทุกสถานะ' },
   { value: 'active', label: 'เปิดใช้งาน' },
   { value: 'inactive', label: 'ปิดใช้งาน' },
 ] as const;
-
-const getPanelBorderColor = (theme: any) =>
-  alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1);
-const getPanelShadowColor = (theme: any) =>
-  theme.palette.mode === 'dark' ? alpha(theme.palette.common.black, 0.24) : alpha(theme.palette.primary.main, 0.05);
-const getSurfaceBackground = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
-    : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`;
-const getSectionSurfaceBackground = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.76 : 0.9);
-const getControlSurfaceColor = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.88);
-const getToolbarSurfaceColor = (theme: any) =>
-  theme.palette.mode === 'dark'
-    ? alpha(theme.palette.background.paper, 0.04)
-    : alpha(theme.palette.background.paper, 0.98);
-
-const SectionSurface = styled(Box)(({ theme }) => ({
-  borderRadius: SECTION_RADIUS,
-  border: `1px solid ${getPanelBorderColor(theme)}`,
-  backgroundColor: getSectionSurfaceBackground(theme),
-  boxShadow:
-    theme.palette.mode === 'dark'
-      ? `inset 0 1px 0 ${alpha(theme.palette.common.white, 0.03)}`
-      : `0 10px 22px ${alpha(theme.palette.primary.main, 0.03)}`,
-}));
-
-const SectionTitle = styled(Typography)(({ theme }) => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  fontSize: 'clamp(0.92rem, 0.88rem + 0.14vw, 1rem)',
-  fontWeight: 800,
-  letterSpacing: '-0.01em',
-  color: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.88 : 0.82),
-  '&::before': {
-    content: '""',
-    width: 10,
-    height: 10,
-    borderRadius: 999,
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.72 : 0.64),
-    boxShadow:
-      theme.palette.mode === 'dark'
-        ? `0 0 0 6px ${alpha(theme.palette.primary.main, 0.08)}`
-        : `0 0 0 5px ${alpha(theme.palette.primary.main, 0.08)}`,
-  },
-}));
-
-const SectionDescription = styled(Typography)(({ theme }) => ({
-  marginTop: theme.spacing(0.5),
-  maxWidth: '60ch',
-  fontSize: 'clamp(0.94rem, 0.9rem + 0.16vw, 1rem)',
-  fontWeight: 500,
-  lineHeight: 1.6,
-  color: theme.palette.mode === 'dark' ? alpha(theme.palette.text.primary, 0.8) : theme.palette.text.secondary,
-}));
-
-const ToolButton = styled(IconButton)(({ theme }) => ({
-  width: '100%',
-  minWidth: 54,
-  height: 52,
-  borderRadius: 0,
-  border: 0,
-  backgroundColor: 'transparent',
-  color: theme.palette.primary.main,
-  boxShadow: 'none',
-  transition: 'background-color 180ms ease, color 180ms ease',
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.08),
-  },
-}));
-
-const ToolButtonSlot = styled(Box)({
-  display: 'flex',
-  flex: '1 1 0',
-  minWidth: 0,
-});
-
-const ToolDivider = styled(Box)(({ theme }) => ({
-  width: 1,
-  alignSelf: 'stretch',
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.16),
-}));
-
-const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-  },
-}));
-
-const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
-  '& .MuiDataGrid-columnHeader[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="name"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-}));
-
-const CONTROL_SX = {
-  '& .MuiOutlinedInput-root': {
-    borderRadius: `${CONTROL_RADIUS}px`,
-    backgroundColor: (theme: any) => getControlSurfaceColor(theme),
-    '& fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-    },
-    '&:hover fieldset': {
-      borderColor: (theme: any) => alpha(theme.palette.primary.main, 0.28),
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: 'primary.main',
-    },
-  },
-  '& .MuiInputBase-input': {
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-root': {
-    fontSize: '0.92rem',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-  },
-  '& .MuiInputLabel-shrink': {
-    fontSize: '0.86rem',
-  },
-} as const;
 
 const getErrorMessage = (error: any, fallback: string) => {
   if (typeof error?.response?.data?.message === 'string') {
@@ -640,10 +504,16 @@ const ProgramSettingsPage = () => {
         <Grid size={12}>
           <Card
             sx={{
-              borderRadius: `${PANEL_RADIUS}px`,
-              border: (theme) => `1px solid ${getPanelBorderColor(theme)}`,
-              background: (theme) => getSurfaceBackground(theme),
-              boxShadow: (theme) => `0 22px 44px ${getPanelShadowColor(theme)}`,
+              borderRadius: 6,
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1)}`,
+              background: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${alpha(theme.palette.background.paper, 0.985)} 18%, ${alpha(theme.palette.background.paper, 0.995)} 100%)`
+                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.028)} 0%, ${alpha(theme.palette.background.paper, 0.992)} 16%, ${theme.palette.background.paper} 100%)`,
+              boxShadow: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `0 22px 44px ${alpha(theme.palette.common.black, 0.24)}`
+                  : `0 22px 44px ${alpha(theme.palette.primary.main, 0.05)}`,
             }}
           >
             <CardHeader
@@ -693,7 +563,7 @@ const ProgramSettingsPage = () => {
             />
 
             <CardContent sx={{ px: { xs: 4, sm: 5, md: 6 }, pt: 2, pb: { xs: 4, sm: 5 } }}>
-              <SectionSurface sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
+              <SectionBox sx={{ p: { xs: 3, sm: 3.5 }, mb: 4 }}>
                 <Grid container spacing={3} sx={{ alignItems: 'flex-end' }}>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <SectionTitle>ค้นหาและกรอง</SectionTitle>
@@ -714,8 +584,11 @@ const ProgramSettingsPage = () => {
                           display: 'inline-flex',
                           alignItems: 'stretch',
                           overflow: 'hidden',
-                          borderRadius: TOOLBAR_RADIUS,
-                          bgcolor: (theme) => getToolbarSurfaceColor(theme),
+                          borderRadius: 14,
+                          bgcolor: (theme) =>
+                            theme.palette.mode === 'dark'
+                              ? alpha(theme.palette.background.paper, 0.04)
+                              : alpha(theme.palette.background.paper, 0.98),
                           border: (theme) =>
                             `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.18)}`,
                           boxShadow: (theme) =>
@@ -780,23 +653,21 @@ const ProgramSettingsPage = () => {
                     </Box>
                   </Grid>
                   <Grid size={{ xs: 12, md: 5 }}>
-                    <TextField
+                    <AppFilterTextField
                       fullWidth
                       label='ค้นหาสาขา'
                       placeholder='พิมพ์ชื่อสาขา รหัสสาขา หรือคำอธิบาย'
                       value={searchText}
                       onChange={(event) => setSearchText(event.target.value)}
-                      sx={CONTROL_SX}
                     />
                   </Grid>
                   <Grid size={{ xs: 12, md: 3.5 }}>
-                    <TextField
+                    <AppFilterTextField
                       select
                       fullWidth
                       label='แผนก'
                       value={departmentFilter}
                       onChange={(event) => setDepartmentFilter(event.target.value)}
-                      sx={CONTROL_SX}
                     >
                       <MenuItem value='all'>ทุกแผนก</MenuItem>
                       {departments.map((department) => (
@@ -804,26 +675,25 @@ const ProgramSettingsPage = () => {
                           {department.name}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                   <Grid size={{ xs: 12, md: 3.5 }}>
-                    <TextField
+                    <AppFilterTextField
                       select
                       fullWidth
                       label='สถานะ'
                       value={statusFilter}
                       onChange={(event) => setStatusFilter(event.target.value as 'all' | 'active' | 'inactive')}
-                      sx={CONTROL_SX}
                     >
                       {STATUS_OPTIONS.map((option) => (
                         <MenuItem key={option.value} value={option.value}>
                           {option.label}
                         </MenuItem>
                       ))}
-                    </TextField>
+                    </AppFilterTextField>
                   </Grid>
                 </Grid>
-              </SectionSurface>
+              </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
                 {[
@@ -853,7 +723,7 @@ const ProgramSettingsPage = () => {
                   },
                 ].map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
-                    <SectionSurface sx={{ p: 3, height: '100%' }}>
+                    <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
                         <Avatar
                           variant='rounded'
@@ -882,12 +752,12 @@ const ProgramSettingsPage = () => {
                       }}>
                         {item.hint}
                       </Typography>
-                    </SectionSurface>
+                    </SectionBox>
                   </Grid>
                 ))}
               </Grid>
 
-              <SectionSurface sx={{ p: { xs: 2, sm: 2.5 } }}>
+              <SectionBox sx={{ p: { xs: 2, sm: 2.5 } }}>
                 <Box
                   sx={{
                     px: { xs: 1, sm: 1.5 },
@@ -909,7 +779,7 @@ const ProgramSettingsPage = () => {
                 </Box>
 
                 <Box sx={{ width: '100%' }}>
-                  <StyledDataGrid
+                  <AppSettingsDataGrid
                     autoHeight
                     rows={filteredPrograms}
                     columns={columns}
@@ -929,7 +799,7 @@ const ProgramSettingsPage = () => {
                     pageSizeOptions={[10, 25, 50]}
                   />
                 </Box>
-              </SectionSurface>
+              </SectionBox>
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -32,7 +32,7 @@ import { toast } from 'react-toastify';
 
 import httpClient from '@/@core/utils/http';
 import CustomNoRowsOverlay from '@/@core/components/check-in/CustomNoRowsOverlay';
-import Icon from '@/@core/components/icon';
+import Icon, { ColorIcon } from '@/@core/components/icon';
 import { authConfig } from '@/configs/auth';
 import {
   useCreateProgram,
@@ -377,15 +377,11 @@ const ProgramSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'info.main', display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}>
-              <Icon icon='tabler:building' fontSize='0.9rem' />
-            </Box>
+            <ColorIcon icon='tabler:building' color='info' fontSize='0.9rem' />
             <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.65 }}>
-              <Icon icon='tabler:school' fontSize='0.85rem' />
-            </Box>
+            <ColorIcon icon='tabler:school' color='primary' fontSize='0.85rem' opacity={0.65} />
             <Typography variant='caption' color='text.secondary'>
               {row.level?.levelName || 'ไม่ระบุระดับชั้น'}
             </Typography>
@@ -402,25 +398,19 @@ const ProgramSettingsPage = () => {
       renderCell: ({ row }) => (
         <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
-            <Box component='span' sx={{ color: 'success.main', display: 'inline-flex', flexShrink: 0, opacity: 0.85 }}>
-              <Icon icon='tabler:users' fontSize='0.9rem' />
-            </Box>
+            <ColorIcon icon='tabler:users' color='success' fontSize='0.9rem' opacity={0.85} />
             <Typography variant='body2'>
               นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'warning.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
-                <Icon icon='tabler:door' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:door' color='warning' fontSize='0.85rem' opacity={0.75} />
               <Typography variant='caption' color='text.secondary'>ห้อง {row._count?.classroom ?? 0}</Typography>
             </Box>
             <Typography variant='caption' color='text.disabled'>·</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box component='span' sx={{ color: 'primary.main', display: 'inline-flex', flexShrink: 0, opacity: 0.75 }}>
-                <Icon icon='tabler:user-star' fontSize='0.85rem' />
-              </Box>
+              <ColorIcon icon='tabler:user-star' color='primary' fontSize='0.85rem' opacity={0.75} />
               <Typography variant='caption' color='text.secondary'>ครู {row._count?.teacher ?? 0}</Typography>
             </Box>
           </Box>

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -24,8 +24,9 @@ import {
   Typography,
 } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { type GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
+import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
 import { useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'react-toastify';
 
@@ -151,32 +152,16 @@ const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
   },
 }));
 
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
-  border: 0,
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
+const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-columnHeader[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 700,
-    color: theme.palette.text.primary,
-  },
-  '& .MuiDataGrid-row': {
-    transition: 'background-color 180ms ease',
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    },
-  },
-  '& .MuiDataGrid-cell': {
-    display: 'flex',
-    alignItems: 'center',
-    whiteSpace: 'normal',
-    lineHeight: 'unset !important',
-  },
-  '& .MuiDataGrid-footerContainer': {
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    backgroundColor: alpha(theme.palette.background.paper, 0.72),
+  '& .MuiDataGrid-cell[data-field="name"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
 }));
 

--- a/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
+++ b/frontend/src/views/apps/settings/program/ProgramSettingsPage.tsx
@@ -346,15 +346,25 @@ const ProgramSettingsPage = () => {
           >
             {row.name || '-'}
           </Typography>
-          <Typography
-            variant='caption'
+          <Box
+            component='span'
             sx={{
-              color: 'text.secondary',
-              display: 'block',
-              mt: 0.25
-            }}>
-            {row.programId || 'ยังไม่กำหนดรหัสสาขา'}
-          </Typography>
+              display: 'inline-block',
+              mt: 0.5,
+              px: 0.75,
+              py: 0.1,
+              borderRadius: 1,
+              fontSize: '0.72rem',
+              fontFamily: 'monospace',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+              color: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.9 : 0.75),
+              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+            }}
+          >
+            {row.programId || '—'}
+          </Box>
         </Box>
       ),
     },
@@ -365,13 +375,17 @@ const ProgramSettingsPage = () => {
       minWidth: 190,
       sortable: false,
       renderCell: ({ row }) => (
-        <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
-          <Typography variant='caption' sx={{
-            color: 'text.secondary'
-          }}>
-            {row.level?.levelName || 'ไม่ระบุระดับชั้น'}
-          </Typography>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:building' fontSize='0.9rem' style={{ opacity: 0.55, flexShrink: 0 }} />
+            <Typography variant='body2'>{row.department?.name || 'ไม่ระบุแผนก'}</Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:school' fontSize='0.85rem' style={{ opacity: 0.45, flexShrink: 0 }} />
+            <Typography variant='caption' color='text.secondary'>
+              {row.level?.levelName || 'ไม่ระบุระดับชั้น'}
+            </Typography>
+          </Box>
         </Box>
       ),
     },
@@ -382,13 +396,24 @@ const ProgramSettingsPage = () => {
       minWidth: 175,
       sortable: false,
       renderCell: ({ row }) => (
-        <Box sx={{ py: 1.5 }}>
-          <Typography variant='body2'>นักเรียน {row._count?.student ?? 0} คน</Typography>
-          <Typography variant='caption' sx={{
-            color: 'text.secondary'
-          }}>
-            ห้องเรียน {row._count?.classroom ?? 0} • ครู {row._count?.teacher ?? 0}
-          </Typography>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Icon icon='tabler:users' fontSize='0.9rem' style={{ opacity: 0.6, flexShrink: 0 }} />
+            <Typography variant='body2'>
+              นักเรียน <strong>{row._count?.student ?? 0}</strong> คน
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:door' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>ห้อง {row._count?.classroom ?? 0}</Typography>
+            </Box>
+            <Typography variant='caption' color='text.disabled'>·</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Icon icon='tabler:user-star' fontSize='0.85rem' style={{ opacity: 0.5, flexShrink: 0 }} />
+              <Typography variant='caption' color='text.secondary'>ครู {row._count?.teacher ?? 0}</Typography>
+            </Box>
+          </Box>
         </Box>
       ),
     },
@@ -419,19 +444,14 @@ const ProgramSettingsPage = () => {
         const formatted = formatThaiDateTimeParts(row.updatedAt);
 
         return (
-          <Box sx={{ py: 1.5 }}>
-            <Typography variant='body2' sx={{
-              color: 'text.secondary'
-            }}>
-              {formatted.date}
-            </Typography>
-            {formatted.time ? (
-              <Typography variant='caption' sx={{
-                color: 'text.secondary'
-              }}>
-                {formatted.time}
-              </Typography>
-            ) : null}
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75, py: 0.5 }}>
+            <Icon icon='tabler:calendar-event' fontSize='0.95rem' style={{ opacity: 0.45, flexShrink: 0, marginTop: 2 }} />
+            <Box>
+              <Typography variant='body2' color='text.secondary'>{formatted.date}</Typography>
+              {formatted.time ? (
+                <Typography variant='caption' color='text.secondary'>{formatted.time}</Typography>
+              ) : null}
+            </Box>
           </Box>
         );
       },
@@ -696,32 +716,14 @@ const ProgramSettingsPage = () => {
               </SectionBox>
 
               <Grid container spacing={3} sx={{ mb: 4 }}>
-                {[
-                  {
-                    label: 'สาขาทั้งหมด',
-                    value: summary.total,
-                    hint: `${summary.active} เปิดใช้งาน`,
-                    icon: 'tabler:books',
-                  },
-                  {
-                    label: 'ปิดใช้งาน',
-                    value: summary.inactive,
-                    hint: 'พักใช้งานชั่วคราว',
-                    icon: 'tabler:book-off',
-                  },
-                  {
-                    label: 'นักเรียนที่ผูกอยู่',
-                    value: summary.students,
-                    hint: 'รวมทั้งระบบ',
-                    icon: 'tabler:users',
-                  },
-                  {
-                    label: 'ห้องเรียนที่ผูกอยู่',
-                    value: summary.classrooms,
-                    hint: 'พร้อมใช้งานต่อในระบบ',
-                    icon: 'tabler:door',
-                  },
-                ].map((item) => (
+                {(
+                  [
+                    { label: 'สาขาทั้งหมด', value: summary.total, hint: `${summary.active} เปิดใช้งาน`, icon: 'tabler:books', colorKey: 'primary' },
+                    { label: 'ปิดใช้งาน', value: summary.inactive, hint: 'พักใช้งานชั่วคราว', icon: 'tabler:book-off', colorKey: 'warning' },
+                    { label: 'นักเรียนที่ผูกอยู่', value: summary.students, hint: 'รวมทั้งระบบ', icon: 'tabler:users', colorKey: 'info' },
+                    { label: 'ห้องเรียนที่ผูกอยู่', value: summary.classrooms, hint: 'พร้อมใช้งานต่อในระบบ', icon: 'tabler:door', colorKey: 'success' },
+                  ] as Array<{ label: string; value: number; hint: string; icon: string; colorKey: 'primary' | 'warning' | 'info' | 'success' }>
+                ).map((item) => (
                   <Grid key={item.label} size={{ xs: 12, sm: 6, xl: 3 }}>
                     <SectionBox sx={{ p: 3, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
@@ -732,24 +734,20 @@ const ProgramSettingsPage = () => {
                             height: 40,
                             borderRadius: 2.5,
                             bgcolor: (theme) =>
-                              alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
-                            color: 'primary.main',
+                              alpha(theme.palette[item.colorKey].main, theme.palette.mode === 'dark' ? 0.18 : 0.1),
+                            color: `${item.colorKey}.main`,
                           }}
                         >
                           <Icon icon={item.icon} fontSize='1.2rem' />
                         </Avatar>
-                        <Typography variant='body2' sx={{
-                          color: 'text.secondary'
-                        }}>
+                        <Typography variant='body2' color='text.secondary'>
                           {item.label}
                         </Typography>
                       </Box>
                       <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.03em' }}>
                         {item.value}
                       </Typography>
-                      <Typography variant='caption' sx={{
-                        color: 'text.secondary'
-                      }}>
+                      <Typography variant='caption' color='text.secondary'>
                         {item.hint}
                       </Typography>
                     </SectionBox>

--- a/frontend/src/views/apps/settings/program/TableHeader.tsx
+++ b/frontend/src/views/apps/settings/program/TableHeader.tsx
@@ -1,6 +1,12 @@
-import { Box, Button, TextField } from '@mui/material';
-import Grid from '@mui/material/Grid';
-import { Plus } from 'mdi-material-ui';
+'use client';
+
+import IconifyIcon from '@/@core/components/icon';
+import { SectionBox } from '@/@core/components/filter-panel';
+import { AppSearchTextField, AppContainedButton } from '@/@core/components/form';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
 import { FaFileExcel } from 'react-icons/fa';
 
 interface TableHeaderProps {
@@ -18,45 +24,67 @@ const TableHeader = ({ value, handleFilter, handleUploadFile, handleUpload, file
   };
 
   return (
-    <Box
-      sx={{
-        px: { xs: 4, sm: 5 },
-        py: { xs: 3, sm: 3.5 },
-        borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-      }}
-    >
-      <Grid container spacing={2} sx={{ alignItems: 'center' }}>
-        <Grid size={{ xs: 12, sm: 6 }}>
-          <TextField
-            fullWidth
+    <Box sx={{ px: { xs: 3, sm: 4, lg: 5 }, pb: { xs: 3, sm: 4 } }}>
+      <SectionBox id='program-list-toolbar-surface'>
+        <Stack
+          id='program-list-toolbar-row'
+          direction={{ xs: 'column', sm: 'row' }}
+          sx={{
+            alignItems: { xs: 'stretch', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: { xs: 1.75, sm: 2 },
+          }}
+        >
+          <AppSearchTextField
+            id='program-search-input'
             size='small'
             value={value}
+            placeholder='ค้นหาสาขาวิชา...'
             onChange={(e) => handleFilter(e.target.value)}
-            placeholder='ค้นหา...'
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position='start'>
+                    <IconifyIcon icon='tabler:search' fontSize='1.1rem' />
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{ width: { xs: '100%', md: 280 }, flex: { xs: '1 1 auto', md: '0 1 280px' } }}
           />
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6 }}>
-          <Box sx={{ display: 'flex', gap: 2, justifyContent: { sm: 'flex-end' } }}>
+
+          <Stack direction='row' sx={{ gap: 1.5, width: { xs: '100%', sm: 'auto' } }}>
             <Button
+              id='upload-program-file-button'
               component='label'
               variant='outlined'
               color='success'
               startIcon={<FaFileExcel />}
+              sx={{ flex: { xs: 1, sm: 'none' } }}
             >
               อัปโหลดไฟล์
-              <input hidden accept='.xlsx, .xls' type='file' ref={fileInputRef} onChange={handleFileChange} />
+              <input
+                id='program-file-input'
+                hidden
+                accept='.xlsx, .xls'
+                type='file'
+                ref={fileInputRef}
+                onChange={handleFileChange}
+              />
             </Button>
-            <Button
+            <AppContainedButton
+              id='add-program-button'
               variant='contained'
               disableElevation
-              startIcon={<Plus />}
+              startIcon={<IconifyIcon icon='tabler:plus' />}
               onClick={handleUploadFile}
+              sx={{ flex: { xs: 1, sm: 'none' } }}
             >
               เพิ่มสาขาวิชา
-            </Button>
-          </Box>
-        </Grid>
-      </Grid>
+            </AppContainedButton>
+          </Stack>
+        </Stack>
+      </SectionBox>
     </Box>
   );
 };

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -18,9 +18,9 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { GridColDef } from '@mui/x-data-grid';
-import { alpha, styled } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
-import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import AppListDataGrid from '@/@core/components/data-grid/AppListDataGrid';
 import { AppListCard, AppListCardHeader, type ListSummaryItem } from '@/@core/components/list-page';
 import React, { memo, useMemo, useCallback } from 'react';
 import { RiContactsBookLine, RiUserSearchLine, RiUserUnfollowLine, RiGraduationCapLine, RiArrowUpLine } from 'react-icons/ri';
@@ -36,21 +36,6 @@ import StudentBulkGraduationDialog from '@/components/dialogs/StudentBulkGraduat
 import StudentIndividualPromotionDialog from '@/components/dialogs/StudentIndividualPromotionDialog';
 import { useStudentList } from '@/hooks/features/student';
 import type { StudentImportResult } from '@/hooks/queries/useStudents';
-
-// ─── Styled Components ────────────────────────────────────────────────────────
-
-const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
-  '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="fullName"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-}));
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
@@ -493,7 +478,7 @@ const StudentListPage = () => {
               isDeleting={isDeletingAll}
             />
             <Box id='student-list-data-grid'>
-              <StyledDataGrid
+              <AppListDataGrid
                 rows={students}
                 columns={columns}
                 loading={loadingStudent}

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -2,11 +2,8 @@
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Card from '@mui/material/Card';
-import CardHeader from '@mui/material/CardHeader';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -24,6 +21,7 @@ import { GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { AppListCard, AppListCardHeader, type ListSummaryItem } from '@/@core/components/list-page';
 import React, { memo, useMemo, useCallback } from 'react';
 import { RiContactsBookLine, RiUserSearchLine, RiUserUnfollowLine, RiGraduationCapLine, RiArrowUpLine } from 'react-icons/ri';
 import { AccountEditOutline } from 'mdi-material-ui';
@@ -298,9 +296,8 @@ const StudentListPage = () => {
     [students],
   );
 
-  type StudentSummaryColor = 'success' | 'warning' | 'error';
-  const studentSummaryItems = useMemo(() => {
-    const items: { label: string; value: number; color: StudentSummaryColor }[] = [
+  const studentSummaryItems = useMemo<ListSummaryItem[]>(() => {
+    const items: ListSummaryItem[] = [
       { label: 'กำลังศึกษา', value: activeStudentCount, color: 'success' },
       { label: 'จบการศึกษา', value: graduatedCount, color: 'warning' },
     ];
@@ -458,184 +455,15 @@ const StudentListPage = () => {
     <React.Fragment>
       <Grid id='student-list-container' container spacing={6}>
         <Grid size={12}>
-          <Card
-            id='student-list-card'
-            sx={{
-              borderRadius: 3,
-              overflow: 'hidden',
-              border: (theme) =>
-                `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.08)}`,
-              boxShadow: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? `0 18px 42px ${alpha(theme.palette.common.black, 0.24)}`
-                  : `0 18px 42px ${alpha(theme.palette.primary.main, 0.08)}`,
-              background: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 32%)`
-                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 32%)`,
-            }}
-          >
-            <CardHeader
+          <AppListCard id='student-list-card'>
+            <AppListCardHeader
               id='student-list-card-header'
-              avatar={
-                <Avatar
-                  sx={{
-                    color: (theme) => theme.palette.primary.dark,
-                    bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.12),
-                    border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
-                    width: { xs: 42, sm: 48 },
-                    height: { xs: 42, sm: 48 },
-                    boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.16)}`,
-                  }}
-                  aria-label='student-list'
-                >
-                  <RiContactsBookLine />
-                </Avatar>
-              }
-              sx={{
-                color: 'text.primary',
-                alignItems: 'flex-start',
-                px: { xs: 3, sm: 4, lg: 5 },
-                pt: { xs: 3, sm: 4.25 },
-                pb: { xs: 2.5, sm: 3 },
-                '& .MuiCardHeader-avatar': {
-                  mt: 0.25,
-                  mr: { xs: 2, sm: 2.5 },
-                },
-                '& .MuiCardHeader-content': {
-                  minWidth: 0,
-                },
-              }}
-              title={
-                <Stack
-                  direction={{ xs: 'column', sm: 'row' }}
-                  sx={{
-                    alignItems: { xs: 'flex-start', sm: 'center' },
-                    flexWrap: 'wrap',
-                    columnGap: { xs: 1, sm: 1.5 },
-                    rowGap: 0.75,
-                  }}
-                >
-                  <Typography
-                    component='span'
-                    sx={{
-                      fontWeight: 800,
-                      fontSize: { xs: '1.45rem', sm: '1.9rem' },
-                      letterSpacing: { xs: '-0.02em', sm: '-0.03em' },
-                      lineHeight: 1.08,
-                      color: 'text.primary',
-                    }}
-                  >
-                    รายชื่อนักเรียนทั้งหมด
-                  </Typography>
-                  {students.length > 0 && (
-                    <Box
-                      component='span'
-                      sx={{
-                        display: 'inline-flex',
-                        alignItems: 'baseline',
-                        gap: 0.75,
-                        px: 1.4,
-                        py: 0.6,
-                        borderRadius: 999,
-                        bgcolor: (theme) =>
-                          alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
-                        border: (theme) =>
-                          `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.12)}`,
-                        color: 'primary.main',
-                        lineHeight: 1,
-                      }}
-                    >
-                      <Typography
-                        component='span'
-                        sx={{
-                          fontSize: { xs: '1.05rem', sm: '1.15rem' },
-                          fontWeight: 800,
-                          letterSpacing: '-0.02em',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
-                      >
-                        {students.length.toLocaleString('th-TH')}
-                      </Typography>
-                      <Typography
-                        component='span'
-                        sx={{ fontSize: '0.9rem', fontWeight: 700, letterSpacing: '0.01em', color: 'text.secondary' }}
-                      >
-                        คน
-                      </Typography>
-                    </Box>
-                  )}
-                </Stack>
-              }
-              subheader={
-                <Box>
-                  <Typography
-                    component='p'
-                    sx={{
-                      mt: 1.1,
-                      fontSize: 'clamp(0.98rem, 0.94rem + 0.16vw, 1.06rem)',
-                      fontWeight: 500,
-                      letterSpacing: '-0.01em',
-                      color: 'text.secondary',
-                    }}
-                  >
-                    ค้นหา จัดการ และนำเข้าข้อมูลนักเรียนได้จากแผงเดียว
-                  </Typography>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: { xs: 0.75, sm: 1 },
-                      mt: 2.25,
-                      maxWidth: 760,
-                    }}
-                  >
-                    {studentSummaryItems.map((item) => (
-                      <Box
-                        key={item.label}
-                        component='span'
-                        sx={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          gap: 0.75,
-                          px: 1.35,
-                          py: 0.7,
-                          minHeight: 30,
-                          borderRadius: 999,
-                          border: (theme) =>
-                            `1px solid ${alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.26 : 0.18)}`,
-                          bgcolor: (theme) =>
-                            alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.11 : 0.075),
-                        }}
-                      >
-                        <Typography
-                          component='span'
-                          sx={{
-                            fontSize: '0.8rem',
-                            fontWeight: 800,
-                            lineHeight: 1,
-                            color: `${item.color}.dark`,
-                            fontVariantNumeric: 'tabular-nums',
-                          }}
-                        >
-                          {item.value.toLocaleString('th-TH')}
-                        </Typography>
-                        <Typography
-                          component='span'
-                          sx={{ fontSize: '0.78rem', fontWeight: 700, lineHeight: 1, color: 'text.secondary' }}
-                        >
-                          {item.label}
-                        </Typography>
-                      </Box>
-                    ))}
-                  </Box>
-                </Box>
-              }
-              slotProps={{
-                subheader: {
-                  component: 'div',
-                },
-              }}
+              icon={<RiContactsBookLine />}
+              title='รายชื่อนักเรียนทั้งหมด'
+              count={students.length}
+              countUnit='คน'
+              description='ค้นหา จัดการ และนำเข้าข้อมูลนักเรียนได้จากแผงเดียว'
+              summaryItems={studentSummaryItems}
             />
             <TableHeader
               classrooms={classrooms}
@@ -665,24 +493,24 @@ const StudentListPage = () => {
               isDeleting={isDeletingAll}
             />
             <Box id='student-list-data-grid'>
-            <StyledDataGrid
-              rows={students}
-              columns={columns}
-              loading={loadingStudent}
-              disableRowSelectionOnClick
-              disableColumnMenu
-              getRowHeight={() => 'auto'}
-              initialState={{
-                pagination: {
-                  paginationModel: { pageSize, page: 0 },
-                },
-              }}
-              pageSizeOptions={[10, 25, 50]}
-              onPaginationModelChange={handlePaginationModelChange}
-              slots={{ noRowsOverlay: CustomNoRowsOverlay }}
-            />
+              <StyledDataGrid
+                rows={students}
+                columns={columns}
+                loading={loadingStudent}
+                disableRowSelectionOnClick
+                disableColumnMenu
+                getRowHeight={() => 'auto'}
+                initialState={{
+                  pagination: {
+                    paginationModel: { pageSize, page: 0 },
+                  },
+                }}
+                pageSizeOptions={[10, 25, 50]}
+                onPaginationModelChange={handlePaginationModelChange}
+                slots={{ noRowsOverlay: CustomNoRowsOverlay }}
+              />
             </Box>
-          </Card>
+          </AppListCard>
         </Grid>
       </Grid>
       {openDeletedConfirm && (

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -20,9 +20,10 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { GridColDef } from '@mui/x-data-grid';
 import { alpha, styled } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
+import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
 import React, { memo, useMemo, useCallback } from 'react';
 import { RiContactsBookLine, RiUserSearchLine, RiUserUnfollowLine, RiGraduationCapLine, RiArrowUpLine } from 'react-icons/ri';
 import { AccountEditOutline } from 'mdi-material-ui';
@@ -40,62 +41,16 @@ import type { StudentImportResult } from '@/hooks/queries/useStudents';
 
 // ─── Styled Components ────────────────────────────────────────────────────────
 
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
-  border: 0,
-  '& .MuiDataGrid-row': {
-    maxHeight: 'none !important',
-    transition: 'background-color 180ms ease',
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    },
-  },
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.04),
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-  },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 700,
-    color: theme.palette.text.primary,
-  },
-  '& .MuiDataGrid-cell': {
-    display: 'flex',
-    alignItems: 'center',
-    lineHeight: 'unset !important',
-    maxHeight: 'none !important',
-    overflow: 'visible',
-    whiteSpace: 'normal',
-    wordWrap: 'break-word',
-  },
-  '& .MuiDataGrid-renderingZone': {
-    maxHeight: 'none !important',
-  },
-  '& .MuiDataGrid-footerContainer': {
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-    backgroundColor: alpha(theme.palette.background.paper, 0.7),
-    paddingRight: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
-  },
+const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
   '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
     paddingLeft: theme.spacing(3),
     [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
     [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
   },
-  '& .MuiDataGrid-columnHeader[data-field="actions"]': {
-    paddingRight: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
-  },
   '& .MuiDataGrid-cell[data-field="fullName"]': {
     paddingLeft: theme.spacing(3),
     [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
     [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="actions"]': {
-    paddingRight: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
   },
 }));
 

--- a/frontend/src/views/apps/student/list/StudentListPage.tsx
+++ b/frontend/src/views/apps/student/list/StudentListPage.tsx
@@ -16,6 +16,8 @@ import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
@@ -71,43 +73,72 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   '& .MuiDataGrid-footerContainer': {
     borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
     backgroundColor: alpha(theme.palette.background.paper, 0.7),
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-columnHeader[data-field="actions"]': {
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="actions"]': {
+    paddingRight: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingRight: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingRight: theme.spacing(5) },
   },
 }));
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-const StudentNameCell = memo(({ row }: { row: any }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.75 }}>
-    <RenderAvatar row={row.user?.account} />
-    <Box sx={{ display: 'flex', alignItems: 'flex-start', flexDirection: 'column', minWidth: 0 }}>
-      <Typography
-        noWrap
-        variant='body2'
-        sx={{
-          fontWeight: 700,
-          fontSize: '1rem',
-          letterSpacing: '-0.02em',
-          color: 'text.primary',
-        }}
-      >
-        {`${row.user?.account?.title ?? ''}${row.user?.account?.firstName ?? ''} ${row.user?.account?.lastName ?? ''}`.trim()}
-      </Typography>
-      <Typography
-        noWrap
-        variant='caption'
-        sx={{
-          mt: 0.25,
-          fontSize: '0.84rem',
-          fontWeight: 600,
-          letterSpacing: '0.01em',
-          color: 'text.secondary',
-        }}
-      >
-        @{row.user?.username}
-      </Typography>
-    </Box>
-  </Box>
-));
+const StudentNameCell = memo(({ row }: { row: any }) => {
+  const isGrad =
+    row.isGraduation === true || row.studentStatus === 'graduated' || row.studentStatus === 'จบการศึกษา';
+  const isDropped = row.studentStatus === 'ออกก่อนกำหนด';
+
+  return (
+    <Stack direction='row' sx={{ alignItems: 'center', gap: 1.75 }}>
+      <RenderAvatar row={row.user?.account} />
+      <Stack sx={{ minWidth: 0 }}>
+        <Typography
+          noWrap
+          variant='body2'
+          sx={{ fontWeight: 700, fontSize: '1rem', letterSpacing: '-0.02em', color: 'text.primary' }}
+        >
+          {`${row.user?.account?.title ?? ''}${row.user?.account?.firstName ?? ''} ${row.user?.account?.lastName ?? ''}`.trim()}
+        </Typography>
+        <Stack direction='row' sx={{ alignItems: 'center', gap: 0.75, mt: 0.25 }}>
+          <Typography
+            noWrap
+            variant='caption'
+            sx={{ fontSize: '0.84rem', fontWeight: 600, letterSpacing: '0.01em', color: 'text.secondary' }}
+          >
+            @{row.user?.username}
+          </Typography>
+          {(isGrad || isDropped) && (
+            <Chip
+              label={isGrad ? 'จบการศึกษา' : 'ออกก่อนกำหนด'}
+              size='small'
+              color={isGrad ? 'warning' : 'error'}
+              variant='outlined'
+              sx={{ height: 18, fontSize: '0.65rem', fontWeight: 700, '& .MuiChip-label': { px: 0.75 } }}
+            />
+          )}
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+});
 
 interface StudentImportResultDialogProps {
   open: boolean;
@@ -130,7 +161,7 @@ const StudentImportResultDialog = memo(({ open, result, onClose }: StudentImport
   const processedLabel = result.updated && result.updated > 0 ? 'สำเร็จ' : 'นำเข้าได้';
 
   return (
-    <Dialog open={open} fullWidth maxWidth='sm' aria-labelledby='student-import-result-title' onClose={onClose}>
+    <Dialog id='student-import-result-dialog' open={open} fullWidth maxWidth='sm' aria-labelledby='student-import-result-title' onClose={onClose}>
       <DialogTitle id='student-import-result-title'>ผลการนำเข้าข้อมูลนักเรียน</DialogTitle>
       <DialogContent>
         <Alert severity={alertSeverity} sx={{ mb: 4 }}>
@@ -289,6 +320,39 @@ const StudentListPage = () => {
     [setPageSize],
   );
 
+  const activeStudentCount = useMemo(
+    () =>
+      students.filter(
+        (s: any) =>
+          !s.isGraduation &&
+          s.studentStatus !== 'graduated' &&
+          s.studentStatus !== 'จบการศึกษา' &&
+          s.studentStatus !== 'ออกก่อนกำหนด',
+      ).length,
+    [students],
+  );
+  const graduatedCount = useMemo(
+    () =>
+      students.filter(
+        (s: any) => s.isGraduation === true || s.studentStatus === 'graduated' || s.studentStatus === 'จบการศึกษา',
+      ).length,
+    [students],
+  );
+  const droppedCount = useMemo(
+    () => students.filter((s: any) => s.studentStatus === 'ออกก่อนกำหนด').length,
+    [students],
+  );
+
+  type StudentSummaryColor = 'success' | 'warning' | 'error';
+  const studentSummaryItems = useMemo(() => {
+    const items: { label: string; value: number; color: StudentSummaryColor }[] = [
+      { label: 'กำลังศึกษา', value: activeStudentCount, color: 'success' },
+      { label: 'จบการศึกษา', value: graduatedCount, color: 'warning' },
+    ];
+    if (droppedCount > 0) items.push({ label: 'ออกก่อนกำหนด', value: droppedCount, color: 'error' });
+    return items;
+  }, [activeStudentCount, graduatedCount, droppedCount]);
+
   const columns: GridColDef[] = useMemo(
     () => [
       {
@@ -311,11 +375,29 @@ const StudentListPage = () => {
         sortable: false,
         hideSortIcons: true,
         filterable: false,
-        renderCell: ({ row }) => (
-          <Typography noWrap variant='body2'>
-            {row.classroom?.name}
-          </Typography>
-        ),
+        renderCell: ({ row }) =>
+          row.classroom?.name ? (
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                px: 1.25,
+                py: 0.35,
+                borderRadius: 1.5,
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+                border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.14)}`,
+                maxWidth: '100%',
+              }}
+            >
+              <Typography noWrap variant='body2' sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                {row.classroom.name}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant='body2' sx={{ color: 'text.disabled' }}>
+              —
+            </Typography>
+          ),
       },
       {
         flex: 0.24,
@@ -348,14 +430,23 @@ const StudentListPage = () => {
           });
 
           return (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.75, width: '100%' }}>
+            <Stack
+              id={`student-actions-${row?.id}`}
+              direction='row'
+              sx={{ alignItems: 'center', justifyContent: 'center', gap: 0.75, width: '100%' }}
+            >
               <Tooltip title='ดูรายละเอียด'>
-                <IconButton href={`/apps/student/view/${row?.id}`} sx={getActionIconSx('info')}>
+                <IconButton
+                  id={`view-student-${row?.id}`}
+                  href={`/apps/student/view/${row?.id}`}
+                  sx={getActionIconSx('info')}
+                >
                   <RiUserSearchLine fontSize='1rem' />
                 </IconButton>
               </Tooltip>
               <Tooltip title='แก้ไข'>
                 <IconButton
+                  id={`edit-student-${row?.id}`}
                   href={`/apps/student/edit/${row?.id}?classroom=${currentClassroomId}`}
                   sx={getActionIconSx('warning')}
                 >
@@ -364,6 +455,7 @@ const StudentListPage = () => {
               </Tooltip>
               <Tooltip title='เลื่อนชั้น'>
                 <IconButton
+                  id={`promote-student-${row?.id}`}
                   disabled={isGraduated}
                   sx={getActionIconSx('primary')}
                   onClick={(e) => {
@@ -376,6 +468,7 @@ const StudentListPage = () => {
               </Tooltip>
               <Tooltip title={isGraduated ? 'จบแล้ว' : 'จบการศึกษา'}>
                 <IconButton
+                  id={`graduate-student-${row?.id}`}
                   disabled={isGraduated}
                   sx={getActionIconSx('success')}
                   onClick={(e) => {
@@ -388,6 +481,7 @@ const StudentListPage = () => {
               </Tooltip>
               <Tooltip title='ลบข้อมูล'>
                 <IconButton
+                  id={`delete-student-${row?.id}`}
                   sx={getActionIconSx('error')}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -397,7 +491,7 @@ const StudentListPage = () => {
                   <RiUserUnfollowLine fontSize='1rem' />
                 </IconButton>
               </Tooltip>
-            </Box>
+            </Stack>
           );
         },
       },
@@ -407,46 +501,64 @@ const StudentListPage = () => {
 
   return (
     <React.Fragment>
-      <Grid container spacing={6}>
+      <Grid id='student-list-container' container spacing={6}>
         <Grid size={12}>
           <Card
+            id='student-list-card'
             sx={{
               borderRadius: 3,
               overflow: 'hidden',
-              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.08)}`,
-              boxShadow: (theme) => `0 18px 42px ${alpha(theme.palette.primary.main, 0.08)}`,
+              border: (theme) =>
+                `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.08)}`,
+              boxShadow: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? `0 18px 42px ${alpha(theme.palette.common.black, 0.24)}`
+                  : `0 18px 42px ${alpha(theme.palette.primary.main, 0.08)}`,
               background: (theme) =>
-                `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.03)} 0%, ${theme.palette.background.paper} 16%)`,
+                theme.palette.mode === 'dark'
+                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 32%)`
+                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 32%)`,
             }}
           >
             <CardHeader
+              id='student-list-card-header'
               avatar={
                 <Avatar
                   sx={{
-                    color: 'primary.main',
-                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+                    color: (theme) => theme.palette.primary.dark,
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.12),
+                    border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
                     width: { xs: 42, sm: 48 },
                     height: { xs: 42, sm: 48 },
+                    boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.16)}`,
                   }}
-                  aria-label='recipe'
+                  aria-label='student-list'
                 >
                   <RiContactsBookLine />
                 </Avatar>
               }
               sx={{
                 color: 'text.primary',
+                alignItems: 'flex-start',
                 px: { xs: 3, sm: 4, lg: 5 },
-                pt: { xs: 3, sm: 4 },
-                pb: { xs: 2, sm: 2.5 },
+                pt: { xs: 3, sm: 4.25 },
+                pb: { xs: 2.5, sm: 3 },
+                '& .MuiCardHeader-avatar': {
+                  mt: 0.25,
+                  mr: { xs: 2, sm: 2.5 },
+                },
+                '& .MuiCardHeader-content': {
+                  minWidth: 0,
+                },
               }}
               title={
-                <Box
+                <Stack
+                  direction={{ xs: 'column', sm: 'row' }}
                   sx={{
-                    display: 'flex',
                     alignItems: { xs: 'flex-start', sm: 'center' },
-                    flexDirection: { xs: 'column', sm: 'row' },
                     flexWrap: 'wrap',
-                    gap: { xs: 0.75, sm: 1.5 },
+                    columnGap: { xs: 1, sm: 1.5 },
+                    rowGap: 0.75,
                   }}
                 >
                   <Typography
@@ -461,58 +573,112 @@ const StudentListPage = () => {
                   >
                     รายชื่อนักเรียนทั้งหมด
                   </Typography>
-                  <Box
-                    component='span'
+                  {students.length > 0 && (
+                    <Box
+                      component='span'
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'baseline',
+                        gap: 0.75,
+                        px: 1.4,
+                        py: 0.6,
+                        borderRadius: 999,
+                        bgcolor: (theme) =>
+                          alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+                        border: (theme) =>
+                          `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.12)}`,
+                        color: 'primary.main',
+                        lineHeight: 1,
+                      }}
+                    >
+                      <Typography
+                        component='span'
+                        sx={{
+                          fontSize: { xs: '1.05rem', sm: '1.15rem' },
+                          fontWeight: 800,
+                          letterSpacing: '-0.02em',
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {students.length.toLocaleString('th-TH')}
+                      </Typography>
+                      <Typography
+                        component='span'
+                        sx={{ fontSize: '0.9rem', fontWeight: 700, letterSpacing: '0.01em', color: 'text.secondary' }}
+                      >
+                        คน
+                      </Typography>
+                    </Box>
+                  )}
+                </Stack>
+              }
+              subheader={
+                <Box>
+                  <Typography
+                    component='p'
                     sx={{
-                      display: 'inline-flex',
-                      alignItems: 'baseline',
-                      gap: 0.75,
-                      px: 1.4,
-                      py: 0.6,
-                      borderRadius: 999,
-                      bgcolor: (theme) =>
-                        alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
-                      border: (theme) =>
-                        `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.12)}`,
-                      color: 'primary.main',
-                      lineHeight: 1,
+                      mt: 1.1,
+                      fontSize: 'clamp(0.98rem, 0.94rem + 0.16vw, 1.06rem)',
+                      fontWeight: 500,
+                      letterSpacing: '-0.01em',
+                      color: 'text.secondary',
                     }}
                   >
-                    <Typography
-                      component='span'
-                      sx={{
-                        fontSize: { xs: '1.05rem', sm: '1.15rem' },
-                        fontWeight: 800,
-                        letterSpacing: '-0.02em',
-                        fontVariantNumeric: 'tabular-nums',
-                      }}
-                    >
-                      {(students?.length ?? 0).toLocaleString('th-TH')}
-                    </Typography>
-                    <Typography
-                      component='span'
-                      sx={{
-                        fontSize: '0.9rem',
-                        fontWeight: 700,
-                        letterSpacing: '0.01em',
-                        color: 'text.secondary',
-                      }}
-                    >
-                      คน
-                    </Typography>
+                    ค้นหา จัดการ และนำเข้าข้อมูลนักเรียนได้จากแผงเดียว
+                  </Typography>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: { xs: 0.75, sm: 1 },
+                      mt: 2.25,
+                      maxWidth: 760,
+                    }}
+                  >
+                    {studentSummaryItems.map((item) => (
+                      <Box
+                        key={item.label}
+                        component='span'
+                        sx={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 0.75,
+                          px: 1.35,
+                          py: 0.7,
+                          minHeight: 30,
+                          borderRadius: 999,
+                          border: (theme) =>
+                            `1px solid ${alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.26 : 0.18)}`,
+                          bgcolor: (theme) =>
+                            alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.11 : 0.075),
+                        }}
+                      >
+                        <Typography
+                          component='span'
+                          sx={{
+                            fontSize: '0.8rem',
+                            fontWeight: 800,
+                            lineHeight: 1,
+                            color: `${item.color}.dark`,
+                            fontVariantNumeric: 'tabular-nums',
+                          }}
+                        >
+                          {item.value.toLocaleString('th-TH')}
+                        </Typography>
+                        <Typography
+                          component='span'
+                          sx={{ fontSize: '0.78rem', fontWeight: 700, lineHeight: 1, color: 'text.secondary' }}
+                        >
+                          {item.label}
+                        </Typography>
+                      </Box>
+                    ))}
                   </Box>
                 </Box>
               }
-              subheader='ค้นหา จัดการ และนำเข้าข้อมูลนักเรียนได้จากแผงเดียว'
               slotProps={{
                 subheader: {
-                  sx: {
-                    mt: 1.1,
-                    fontSize: 'clamp(0.98rem, 0.94rem + 0.16vw, 1.06rem)',
-                    fontWeight: 500,
-                    letterSpacing: '-0.01em',
-                    color: 'text.secondary',
-                  },
+                  component: 'div',
                 },
               }}
             />
@@ -543,6 +709,7 @@ const StudentListPage = () => {
               isPromoting={isPromoting}
               isDeleting={isDeletingAll}
             />
+            <Box id='student-list-data-grid'>
             <StyledDataGrid
               rows={students}
               columns={columns}
@@ -559,6 +726,7 @@ const StudentListPage = () => {
               onPaginationModelChange={handlePaginationModelChange}
               slots={{ noRowsOverlay: CustomNoRowsOverlay }}
             />
+            </Box>
           </Card>
         </Grid>
       </Grid>

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -1,10 +1,19 @@
 import Icon from '@/@core/components/icon';
 import { FilterGrid, SectionBox, SectionDescription, SectionTitle } from '@/@core/components/filter-panel';
+import { AppFilterTextField, AppFilterFormControl } from '@/@core/components/form';
 import { ActiveToolButton, ToolButton, ToolButtonSlot, ToolDivider } from '@/@core/components/toolbar';
-import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, OutlinedInput, Select, Stack, Tooltip } from '@mui/material';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Grid from '@mui/material/Grid';
 import { alpha, styled } from '@mui/material/styles';
-import TextField from '@mui/material/TextField';
 import { Close } from '@mui/icons-material';
 import Link from 'next/link';
 import { ChangeEvent, memo, useMemo, useRef } from 'react';
@@ -40,14 +49,11 @@ interface TableHeaderProps {
 }
 
 const TOOLBAR_RADIUS = 14;
-const CONTROL_RADIUS = 12;
 
 const getToolbarSurfaceColor = (theme: any) =>
   theme.palette.mode === 'dark'
     ? alpha(theme.palette.background.paper, 0.04)
     : alpha(theme.palette.background.paper, 0.98);
-const getControlSurfaceColor = (theme: any) =>
-  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.82);
 
 const LinkStyled = styled(Link)(({ theme }) => ({
   textDecoration: 'none',
@@ -123,42 +129,6 @@ const TableHeader = memo((props: TableHeaderProps) => {
     void onImportStudents(file);
     event.target.value = '';
   };
-
-  const controlTextFieldSx = {
-    '& .MuiOutlinedInput-root': {
-      borderRadius: `${CONTROL_RADIUS}px`,
-      backgroundColor: (theme: any) => getControlSurfaceColor(theme),
-      color: 'text.primary',
-      fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
-      '& fieldset': {
-        borderColor: (theme: any) => alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-      },
-      '&:hover fieldset': {
-        borderColor: (theme: any) => alpha(theme.palette.primary.main, 0.28),
-      },
-      '&.Mui-focused fieldset': {
-        borderColor: 'primary.main',
-      },
-    },
-    '& .MuiInputBase-input': {
-      letterSpacing: '-0.01em',
-    },
-    '& .MuiInputLabel-root': {
-      fontSize: '0.9rem',
-      fontWeight: 600,
-      letterSpacing: '-0.01em',
-    },
-    '& .MuiInputLabel-shrink': {
-      fontSize: '0.86rem',
-    },
-    '& .MuiSvgIcon-root': {
-      color: 'text.secondary',
-    },
-    '& .MuiFormHelperText-root:not(.Mui-error)': {
-      color: 'text.secondary',
-      fontWeight: 500,
-    },
-  } as const;
 
   return (
     <Grid
@@ -326,34 +296,31 @@ const TableHeader = memo((props: TableHeaderProps) => {
 
           <Grid container spacing={{ xs: 1.5, sm: 2 }}>
             <FilterGrid id='student-list-student-id-filter' size={{ xs: 12, md: 3 }}>
-              <FormControl id='student-id-form-control' fullWidth>
-                <TextField
-                  id='studentId'
-                  fullWidth
-                  label='รหัสนักเรียน'
-                  placeholder='เช่น 654230001'
-                  value={studentId}
-                  onChange={(e) => onHandleStudentId(e.target.value)}
-                  slotProps={{
-                    input: {
-                      endAdornment: studentId && (
-                        <InputAdornment position='end'>
-                          <IconButton
-                            id='clear-student-id-button'
-                            size='small'
-                            edge='end'
-                            onClick={() => onHandleStudentId('')}
-                            aria-label='clear student id'
-                          >
-                            <Close fontSize='small' />
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                  sx={controlTextFieldSx}
-                />
-              </FormControl>
+              <AppFilterTextField
+                id='studentId'
+                fullWidth
+                label='รหัสนักเรียน'
+                placeholder='เช่น 654230001'
+                value={studentId}
+                onChange={(e) => onHandleStudentId(e.target.value)}
+                slotProps={{
+                  input: {
+                    endAdornment: studentId && (
+                      <InputAdornment position='end'>
+                        <IconButton
+                          id='clear-student-id-button'
+                          size='small'
+                          edge='end'
+                          onClick={() => onHandleStudentId('')}
+                          aria-label='clear student id'
+                        >
+                          <Close fontSize='small' />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
             </FilterGrid>
 
             <FilterGrid id='student-list-student-name-filter' size={{ xs: 12, md: 3 }}>
@@ -383,7 +350,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
                     </li>
                   )}
                   renderInput={(params: any) => (
-                    <TextField
+                    <AppFilterTextField
                       id='student-name-input'
                       {...params}
                       label='ชื่อ-สกุล นักเรียน'
@@ -393,7 +360,6 @@ const TableHeader = memo((props: TableHeaderProps) => {
                         input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
                         inputLabel: { shrink: true },
                       }}
-                      sx={controlTextFieldSx}
                     />
                   )}
                   noOptionsText='ไม่พบข้อมูล'
@@ -419,7 +385,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
                   groupBy={(option: any) => option.department?.name}
                   sx={{ '& .MuiAutocomplete-clearIndicator': { visibility: defaultClassroom ? 'visible' : 'hidden' } }}
                   renderInput={(params: any) => (
-                    <TextField
+                    <AppFilterTextField
                       id='classroom-input'
                       {...params}
                       label='ห้องเรียน'
@@ -431,7 +397,6 @@ const TableHeader = memo((props: TableHeaderProps) => {
                         input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
                         inputLabel: { shrink: true },
                       }}
-                      sx={controlTextFieldSx}
                     />
                   )}
                   noOptionsText='ไม่พบข้อมูล'
@@ -440,7 +405,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
             </FilterGrid>
 
             <FilterGrid id='student-list-status-filter' size={{ xs: 12, md: 3 }}>
-              <FormControl fullWidth sx={controlTextFieldSx}>
+              <AppFilterFormControl fullWidth>
                 <InputLabel id='student-status-label' shrink>
                   สถานะนักเรียน
                 </InputLabel>
@@ -482,7 +447,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
                   <MenuItem value='จบการศึกษา'>จบการศึกษา</MenuItem>
                   <MenuItem value='ออกก่อนกำหนด'>ไม่เรียนแล้ว</MenuItem>
                 </Select>
-              </FormControl>
+              </AppFilterFormControl>
             </FilterGrid>
           </Grid>
         </SectionBox>

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -1,5 +1,7 @@
 import Icon from '@/@core/components/icon';
-import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, OutlinedInput, Select, Stack, Tooltip, Typography } from '@mui/material';
+import { FilterGrid, SectionBox, SectionDescription, SectionTitle } from '@/@core/components/filter-panel';
+import { ActiveToolButton, ToolButton, ToolButtonSlot, ToolDivider } from '@/@core/components/toolbar';
+import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, OutlinedInput, Select, Stack, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { alpha, styled } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
@@ -37,14 +39,9 @@ interface TableHeaderProps {
   isDeleting?: boolean;
 }
 
-const PANEL_RADIUS = 16;
 const TOOLBAR_RADIUS = 14;
 const CONTROL_RADIUS = 12;
 
-const getPanelBorderColor = (theme: any) =>
-  alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1);
-const getPanelShadowColor = (theme: any) =>
-  theme.palette.mode === 'dark' ? alpha(theme.palette.common.black, 0.28) : alpha(theme.palette.primary.main, 0.06);
 const getToolbarSurfaceColor = (theme: any) =>
   theme.palette.mode === 'dark'
     ? alpha(theme.palette.background.paper, 0.04)
@@ -52,99 +49,9 @@ const getToolbarSurfaceColor = (theme: any) =>
 const getControlSurfaceColor = (theme: any) =>
   alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.96 : 0.82);
 
-// ─── Styled Components ────────────────────────────────────────────────────────
-
 const LinkStyled = styled(Link)(({ theme }) => ({
   textDecoration: 'none',
   color: theme.palette.primary.main,
-}));
-
-const FilterGrid = styled(Grid)({
-  display: 'flex',
-  alignItems: 'center',
-});
-
-const SectionBox = styled(Box)(({ theme }) => ({
-  width: '100%',
-  borderRadius: PANEL_RADIUS,
-  border: `1px solid ${getPanelBorderColor(theme)}`,
-  background:
-    theme.palette.mode === 'dark'
-      ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 34%, ${alpha(theme.palette.secondary.main, 0.08)} 100%)`
-      : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 38%, ${alpha(theme.palette.secondary.main, 0.04)} 100%)`,
-  boxShadow: `0 12px 28px ${getPanelShadowColor(theme)}`,
-  padding: theme.spacing(2),
-  [theme.breakpoints.up('sm')]: {
-    padding: theme.spacing(3),
-  },
-  [theme.breakpoints.up('lg')]: {
-    padding: theme.spacing(3.5),
-  },
-}));
-
-const SectionTitle = styled(Typography)(({ theme }) => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  fontSize: 'clamp(0.92rem, 0.86rem + 0.16vw, 1rem)',
-  fontWeight: 800,
-  letterSpacing: '-0.01em',
-  color: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.88 : 0.82),
-  textShadow: theme.palette.mode === 'dark' ? `0 1px 10px ${alpha(theme.palette.primary.main, 0.12)}` : 'none',
-  '&::before': {
-    content: '""',
-    width: 10,
-    height: 10,
-    borderRadius: 999,
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.72 : 0.64),
-    boxShadow:
-      theme.palette.mode === 'dark'
-        ? `0 0 0 6px ${alpha(theme.palette.primary.main, 0.08)}`
-        : `0 0 0 5px ${alpha(theme.palette.primary.main, 0.08)}`,
-  },
-}));
-
-const SectionDescription = styled(Typography)(({ theme }) => ({
-  marginTop: theme.spacing(0.5),
-  color: theme.palette.mode === 'dark' ? alpha(theme.palette.text.primary, 0.82) : theme.palette.text.secondary,
-  maxWidth: '62ch',
-  fontSize: 'clamp(0.94rem, 0.9rem + 0.18vw, 1.06rem)',
-  fontWeight: 500,
-  lineHeight: 1.6,
-}));
-
-const ToolButton = styled(IconButton)(({ theme }) => ({
-  width: '100%',
-  minWidth: 54,
-  height: 52,
-  borderRadius: 0,
-  border: 0,
-  backgroundColor: 'transparent',
-  color: theme.palette.primary.main,
-  boxShadow: 'none',
-  transition: 'background-color 180ms ease, color 180ms ease',
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, 0.08),
-  },
-}));
-
-const ToolButtonSlot = styled('span')({
-  display: 'flex',
-  flex: '1 1 0',
-  minWidth: 0,
-});
-
-const ToolDivider = styled(Box)(({ theme }) => ({
-  width: 1,
-  alignSelf: 'stretch',
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.16),
-}));
-
-const ActiveToolButton = styled(ToolButton)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.12),
-  '&:hover': {
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-  },
 }));
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -1,15 +1,13 @@
 import Icon from '@/@core/components/icon';
 import { FilterGrid, SectionBox, SectionDescription, SectionTitle } from '@/@core/components/filter-panel';
-import { AppFilterTextField, AppFilterFormControl } from '@/@core/components/form';
+import { AppFilterTextField, AppFilterFormControl, AppFilterAutocomplete, AppFilterSelect } from '@/@core/components/form';
 import { ActiveToolButton, ToolButton, ToolButtonSlot, ToolDivider } from '@/@core/components/toolbar';
-import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import OutlinedInput from '@mui/material/OutlinedInput';
-import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Grid from '@mui/material/Grid';
@@ -324,84 +322,80 @@ const TableHeader = memo((props: TableHeaderProps) => {
             </FilterGrid>
 
             <FilterGrid id='student-list-student-name-filter' size={{ xs: 12, md: 3 }}>
-              <FormControl id='student-name-form-control' fullWidth>
-                <Autocomplete
-                  id='studentName'
-                  fullWidth
-                  disablePortal={false}
-                  value={fullName || null}
-                  options={Array.isArray(students) ? students : []}
-                  loading={loadingStudents}
-                  onInputChange={onSearchChange}
-                  onChange={(_, newValue: any) => onHandleChangeStudent(_, newValue)}
-                  sx={{
-                    '& .MuiAutocomplete-clearIndicator': { visibility: fullName ? 'visible' : 'hidden' },
-                  }}
-                  getOptionLabel={getStudentLabel}
-                  isOptionEqualToValue={(option: any, value: any) => {
-                    if (typeof option === 'string' || typeof value === 'string') {
-                      return option === value;
-                    }
-                    return option?.id === value?.id;
-                  }}
-                  renderOption={(props, option: any) => (
-                    <li {...props} key={option.id}>
-                      {getStudentLabel(option)}
-                    </li>
-                  )}
-                  renderInput={(params: any) => (
-                    <AppFilterTextField
-                      id='student-name-input'
-                      {...params}
-                      label='ชื่อ-สกุล นักเรียน'
-                      placeholder='ค้นหาชื่อหรือนามสกุล'
-                      slotProps={{
-                        ...params.slotProps,
-                        input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
-                        inputLabel: { shrink: true },
-                      }}
-                    />
-                  )}
-                  noOptionsText='ไม่พบข้อมูล'
-                />
-              </FormControl>
+              <AppFilterAutocomplete
+                id='studentName'
+                fullWidth
+                disablePortal={false}
+                value={fullName || null}
+                options={Array.isArray(students) ? students : []}
+                loading={loadingStudents}
+                onInputChange={onSearchChange}
+                onChange={(_, newValue: any) => onHandleChangeStudent(_, newValue)}
+                sx={{
+                  '& .MuiAutocomplete-clearIndicator': { visibility: fullName ? 'visible' : 'hidden' },
+                }}
+                getOptionLabel={getStudentLabel}
+                isOptionEqualToValue={(option: any, value: any) => {
+                  if (typeof option === 'string' || typeof value === 'string') {
+                    return option === value;
+                  }
+                  return option?.id === value?.id;
+                }}
+                renderOption={(props: any, option: any) => (
+                  <li {...props} key={option.id}>
+                    {getStudentLabel(option)}
+                  </li>
+                )}
+                renderInput={(params: any) => (
+                  <AppFilterTextField
+                    id='student-name-input'
+                    {...params}
+                    label='ชื่อ-สกุล นักเรียน'
+                    placeholder='ค้นหาชื่อหรือนามสกุล'
+                    slotProps={{
+                      ...params.slotProps,
+                      input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
+                      inputLabel: { shrink: true },
+                    }}
+                  />
+                )}
+                noOptionsText='ไม่พบข้อมูล'
+              />
             </FilterGrid>
 
             <FilterGrid id='student-list-classroom-filter' size={{ xs: 12, md: 3 }}>
-              <FormControl id='classroom-form-control' fullWidth>
-                <Autocomplete
-                  id='classroom'
-                  fullWidth
-                  disablePortal={false}
-                  value={defaultClassroom || null}
-                  options={sortedClassrooms}
-                  loading={loading}
-                  onChange={(_, newValue: any) => onHandleChange(_, newValue)}
-                  getOptionLabel={(option: any) => option?.name ?? ''}
-                  isOptionEqualToValue={(option: any, value: any) => {
-                    if (!option || !value) return false;
-                    return option.id === value.id;
-                  }}
-                  groupBy={(option: any) => option.department?.name}
-                  sx={{ '& .MuiAutocomplete-clearIndicator': { visibility: defaultClassroom ? 'visible' : 'hidden' } }}
-                  renderInput={(params: any) => (
-                    <AppFilterTextField
-                      id='classroom-input'
-                      {...params}
-                      label='ห้องเรียน'
-                      placeholder='เลือกห้องเรียน'
-                      error={(!classrooms || classrooms.length === 0) && !loading}
-                      helperText={(!classrooms || classrooms.length === 0) && !loading ? 'ไม่พบข้อมูลห้องเรียน' : ''}
-                      slotProps={{
-                        ...params.slotProps,
-                        input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
-                        inputLabel: { shrink: true },
-                      }}
-                    />
-                  )}
-                  noOptionsText='ไม่พบข้อมูล'
-                />
-              </FormControl>
+              <AppFilterAutocomplete
+                id='classroom'
+                fullWidth
+                disablePortal={false}
+                value={defaultClassroom || null}
+                options={sortedClassrooms}
+                loading={loading}
+                onChange={(_, newValue: any) => onHandleChange(_, newValue)}
+                getOptionLabel={(option: any) => option?.name ?? ''}
+                isOptionEqualToValue={(option: any, value: any) => {
+                  if (!option || !value) return false;
+                  return option.id === value.id;
+                }}
+                groupBy={(option: any) => option.department?.name}
+                sx={{ '& .MuiAutocomplete-clearIndicator': { visibility: defaultClassroom ? 'visible' : 'hidden' } }}
+                renderInput={(params: any) => (
+                  <AppFilterTextField
+                    id='classroom-input'
+                    {...params}
+                    label='ห้องเรียน'
+                    placeholder='เลือกห้องเรียน'
+                    error={(!classrooms || classrooms.length === 0) && !loading}
+                    helperText={(!classrooms || classrooms.length === 0) && !loading ? 'ไม่พบข้อมูลห้องเรียน' : ''}
+                    slotProps={{
+                      ...params.slotProps,
+                      input: { ...params.slotProps?.input, ...(params.slotProps?.input ?? {}) },
+                      inputLabel: { shrink: true },
+                    }}
+                  />
+                )}
+                noOptionsText='ไม่พบข้อมูล'
+              />
             </FilterGrid>
 
             <FilterGrid id='student-list-status-filter' size={{ xs: 12, md: 3 }}>
@@ -409,11 +403,11 @@ const TableHeader = memo((props: TableHeaderProps) => {
                 <InputLabel id='student-status-label' shrink>
                   สถานะนักเรียน
                 </InputLabel>
-                <Select
+                <AppFilterSelect
                   id='student-status-select'
                   labelId='student-status-label'
                   value={studentStatus}
-                  onChange={(e) => onStatusChange(e.target.value)}
+                  onChange={(e) => onStatusChange(e.target.value as string)}
                   displayEmpty
                   input={
                     <OutlinedInput
@@ -436,17 +430,12 @@ const TableHeader = memo((props: TableHeaderProps) => {
                       }
                     />
                   }
-                  sx={{
-                    '& .MuiSelect-select': {
-                      fontSize: 'clamp(1rem, 0.96rem + 0.14vw, 1.06rem)',
-                    },
-                  }}
                 >
                   <MenuItem value=''>ทุกสถานะ</MenuItem>
                   <MenuItem value='กำลังศึกษา'>เรียนอยู่</MenuItem>
                   <MenuItem value='จบการศึกษา'>จบการศึกษา</MenuItem>
                   <MenuItem value='ออกก่อนกำหนด'>ไม่เรียนแล้ว</MenuItem>
-                </Select>
+                </AppFilterSelect>
               </AppFilterFormControl>
             </FilterGrid>
           </Grid>

--- a/frontend/src/views/apps/student/list/TableHeader.tsx
+++ b/frontend/src/views/apps/student/list/TableHeader.tsx
@@ -1,5 +1,5 @@
 import Icon from '@/@core/components/icon';
-import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, OutlinedInput, Select, Tooltip, Typography } from '@mui/material';
+import { Autocomplete, Box, FormControl, IconButton, InputAdornment, InputLabel, MenuItem, OutlinedInput, Select, Stack, Tooltip, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { alpha, styled } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
@@ -259,17 +259,16 @@ const TableHeader = memo((props: TableHeaderProps) => {
       container
       spacing={3}
       sx={{
-        px: { xs: 2.25, sm: 4, lg: 5 },
+        px: { xs: 3, sm: 4, lg: 5 },
         pb: { xs: 3, sm: 4 },
       }}
     >
       <Grid size={12}>
         <SectionBox id='student-list-filter-surface'>
-          <Box
+          <Stack
             id='student-list-toolbar-row'
+            direction={{ xs: 'column', sm: 'row' }}
             sx={{
-              display: 'flex',
-              flexDirection: { xs: 'column', sm: 'row' },
               alignItems: { xs: 'stretch', sm: 'flex-start', lg: 'center' },
               justifyContent: 'space-between',
               gap: { xs: 1.75, sm: 2 },
@@ -416,7 +415,7 @@ const TableHeader = memo((props: TableHeaderProps) => {
                 </LinkStyled>
               </Tooltip>
             </Box>
-          </Box>
+          </Stack>
 
           <Grid container spacing={{ xs: 1.5, sm: 2 }}>
             <FilterGrid id='student-list-student-id-filter' size={{ xs: 12, md: 3 }}>

--- a/frontend/src/views/apps/teacher/list/TableHeader.tsx
+++ b/frontend/src/views/apps/teacher/list/TableHeader.tsx
@@ -1,9 +1,17 @@
 'use client';
 
-import { Box, Button, Divider, IconButton, InputAdornment, TextField, Tooltip } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import IconifyIcon from '@/@core/components/icon';
-import { useResponsive } from '@/@core/hooks/useResponsive';
+import { SectionBox } from '@/@core/components/filter-panel';
+import { ToolButton, ToolButtonSlot, ToolDivider } from '@/@core/components/toolbar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import { alpha } from '@mui/material/styles';
+
+const TOOLBAR_RADIUS = 14;
 
 interface TableHeaderProps {
   value: string;
@@ -30,195 +38,160 @@ const TableHeader = ({
   isImporting,
   canExport,
 }: TableHeaderProps) => {
-  const { isMobile } = useResponsive();
   const busy = isDownloadingTemplate || isExporting || isImporting;
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: { xs: 2.5, sm: 3 },
-        alignItems: isMobile ? 'stretch' : 'center',
-        px: { xs: 3, sm: 4, lg: 5 },
-        py: { xs: 2.75, sm: 3.25 },
-        borderTop: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1)}`,
-        borderBottom: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.1)}`,
-        background: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.primary.main, 0.06)
-            : alpha(theme.palette.primary.main, 0.025),
-      }}
-    >
-      <TextField
-        size='small'
-        value={value}
-        placeholder='ค้นหา ชื่อ, นามสกุล, ชื่อผู้ใช้'
-        onChange={(e) => handleFilter(e.target.value)}
-        slotProps={{
-          input: {
-            startAdornment: (
-              <InputAdornment position='start'>
-                <IconifyIcon icon='tabler:search' fontSize='1.1rem' />
-              </InputAdornment>
-            ),
-          },
-        }}
-        sx={{
-          width: { xs: '100%', md: 360 },
-          flex: { xs: '1 1 auto', md: '0 1 360px' },
-          '& .MuiOutlinedInput-root': {
-            borderRadius: 2.5,
-            backgroundColor: (theme) => alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.9 : 0.96),
-            transition: 'border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
-            '& .MuiInputAdornment-root': {
-              color: 'primary.main',
-            },
-            '& fieldset': {
-              borderColor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-            },
-            '&:hover fieldset': {
-              borderColor: (theme) => alpha(theme.palette.primary.main, 0.38),
-            },
-            '&.Mui-focused': {
-              backgroundColor: 'background.paper',
-              boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.1)}`,
-            },
-            '&.Mui-focused fieldset': {
-              borderColor: 'primary.main',
-            },
-          },
-        }}
-      />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          gap: { xs: 1.5, sm: 2 },
-          alignItems: { xs: 'stretch', sm: 'center' },
-          ml: isMobile ? 0 : 'auto',
-          justifyContent: { xs: 'stretch', sm: 'flex-end' },
-          minWidth: { xs: '100%', md: 'auto' },
-        }}
-      >
-        <Box
+    <Box sx={{ px: { xs: 3, sm: 4, lg: 5 }, pb: { xs: 3, sm: 4 } }}>
+      <SectionBox id='teacher-list-toolbar-surface'>
+        <Stack
+          id='teacher-list-toolbar-row'
+          direction={{ xs: 'column', sm: 'row' }}
           sx={{
-            display: 'inline-flex',
-            alignItems: 'stretch',
-            width: { xs: '100%', sm: 'auto' },
-            border: (theme) => `1px solid ${alpha(theme.palette.warning.main, theme.palette.mode === 'dark' ? 0.26 : 0.2)}`,
-            borderRadius: 2.5,
-            overflow: 'hidden',
-            backgroundColor: (theme) => alpha(theme.palette.warning.main, theme.palette.mode === 'dark' ? 0.08 : 0.06),
-            '& > span': {
-              display: 'flex',
-              flex: { xs: '1 1 0', sm: '0 0 auto' },
-            },
+            alignItems: { xs: 'stretch', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: { xs: 1.75, sm: 2 },
           }}
         >
-          <Tooltip title={isDownloadingTemplate ? 'กำลังดาวน์โหลด...' : 'ดาวน์โหลด Template'}>
-            <span>
-              <IconButton
-                id='download-teacher-template-button'
-                size='small'
-                disabled={busy}
-                onClick={onDownloadTemplate}
-                sx={{
-                  borderRadius: 0,
-                  width: { xs: '100%', sm: 'auto' },
-                  px: 1.75,
-                  py: 1,
-                  color: 'warning.dark',
-                  '&:hover': {
-                    backgroundColor: (theme) => alpha(theme.palette.warning.main, 0.14),
-                  },
-                }}
-              >
-                <IconifyIcon icon='tabler:file-download' width={18} />
-              </IconButton>
-            </span>
-          </Tooltip>
+          <TextField
+            id='teacher-search-input'
+            size='small'
+            value={value}
+            placeholder='ค้นหา ชื่อ, นามสกุล, ชื่อผู้ใช้'
+            onChange={(e) => handleFilter(e.target.value)}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position='start'>
+                    <IconifyIcon icon='tabler:search' fontSize='1.1rem' />
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{
+              width: { xs: '100%', md: 360 },
+              flex: { xs: '1 1 auto', md: '0 1 360px' },
+              '& .MuiOutlinedInput-root': {
+                borderRadius: 2.5,
+                backgroundColor: (theme) =>
+                  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.9 : 0.96),
+                transition: 'border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
+                '& .MuiInputAdornment-root': { color: 'primary.main' },
+                '& fieldset': {
+                  borderColor: (theme) =>
+                    alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
+                },
+                '&:hover fieldset': {
+                  borderColor: (theme) => alpha(theme.palette.primary.main, 0.38),
+                },
+                '&.Mui-focused': {
+                  backgroundColor: 'background.paper',
+                  boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.1)}`,
+                },
+                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+              },
+            }}
+          />
 
-          <Divider orientation='vertical' flexItem sx={{ borderColor: (theme) => alpha(theme.palette.warning.main, 0.22) }} />
-
-          <Tooltip title={isImporting ? 'กำลังนำเข้า...' : 'นำเข้าข้อมูล (.xlsx)'}>
-            <span>
-              <IconButton
-                id='import-teacher-button'
-                size='small'
-                disabled={busy}
-                onClick={onImportClick}
-                sx={{
-                  borderRadius: 0,
-                  width: { xs: '100%', sm: 'auto' },
-                  px: 1.75,
-                  py: 1,
-                  color: 'warning.dark',
-                  '&:hover': {
-                    backgroundColor: (theme) => alpha(theme.palette.warning.main, 0.14),
-                  },
-                }}
-              >
-                <IconifyIcon icon='tabler:file-import' width={18} />
-              </IconButton>
-            </span>
-          </Tooltip>
-
-          <Divider orientation='vertical' flexItem sx={{ borderColor: (theme) => alpha(theme.palette.warning.main, 0.22) }} />
-
-          <Tooltip
-            title={
-              isExporting
-                ? 'กำลัง export...'
-                : !canExport
-                  ? 'ไม่มีข้อมูลสำหรับ export'
-                  : 'Export ข้อมูล (.xlsx)'
-            }
+          <Stack
+            direction='row'
+            sx={{ alignItems: 'center', gap: 1.5, ml: { sm: 'auto' } }}
           >
-            <span>
-              <IconButton
-                id='export-teacher-button'
-                size='small'
-                disabled={busy || !canExport}
-                onClick={onExport}
-                sx={{
-                  borderRadius: 0,
-                  width: { xs: '100%', sm: 'auto' },
-                  px: 1.75,
-                  py: 1,
-                  color: 'warning.dark',
-                  '&:hover': {
-                    backgroundColor: (theme) => alpha(theme.palette.warning.main, 0.14),
-                  },
-                }}
-              >
-                <IconifyIcon icon='tabler:database-export' width={18} />
-              </IconButton>
-            </span>
-          </Tooltip>
-        </Box>
+            <Box
+              id='teacher-list-tools-surface'
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'stretch',
+                overflow: 'hidden',
+                borderRadius: TOOLBAR_RADIUS,
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? alpha(theme.palette.background.paper, 0.04)
+                    : alpha(theme.palette.background.paper, 0.98),
+                border: (theme) =>
+                  `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.18)}`,
+                boxShadow: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? `inset 0 1px 0 ${alpha(theme.palette.common.white, 0.04)}`
+                    : `0 8px 20px ${alpha(theme.palette.primary.main, 0.06)}`,
+                width: { xs: '100%', sm: 'auto' },
+              }}
+            >
+              <Tooltip title={isDownloadingTemplate ? 'กำลังดาวน์โหลด...' : 'ดาวน์โหลด Template'}>
+                <ToolButtonSlot>
+                  <ToolButton
+                    id='download-teacher-template-button'
+                    size='small'
+                    disabled={busy}
+                    onClick={onDownloadTemplate}
+                  >
+                    <IconifyIcon icon='tabler:file-download' width={18} />
+                  </ToolButton>
+                </ToolButtonSlot>
+              </Tooltip>
 
-        <Button
-          variant='contained'
-          disableElevation
-          onClick={toggle}
-          startIcon={<IconifyIcon icon='tabler:user-plus' />}
-          sx={{
-            borderRadius: 2.5,
-            whiteSpace: 'nowrap',
-            px: 3,
-            py: 1,
-            minHeight: 40,
-            boxShadow: (theme) => `0 8px 18px ${alpha(theme.palette.primary.main, 0.24)}`,
-            '&:hover': {
-              boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.3)}`,
-            },
-          }}
-        >
-          {isMobile ? 'เพิ่ม' : 'เพิ่มครู / บุคลากร'}
-        </Button>
-      </Box>
+              <ToolDivider />
+
+              <Tooltip title={isImporting ? 'กำลังนำเข้า...' : 'นำเข้าข้อมูล (.xlsx)'}>
+                <ToolButtonSlot>
+                  <ToolButton
+                    id='import-teacher-button'
+                    size='small'
+                    disabled={busy}
+                    onClick={onImportClick}
+                  >
+                    <IconifyIcon icon='tabler:file-import' width={18} />
+                  </ToolButton>
+                </ToolButtonSlot>
+              </Tooltip>
+
+              <ToolDivider />
+
+              <Tooltip
+                title={
+                  isExporting
+                    ? 'กำลัง export...'
+                    : !canExport
+                      ? 'ไม่มีข้อมูลสำหรับ export'
+                      : 'Export ข้อมูล (.xlsx)'
+                }
+              >
+                <ToolButtonSlot>
+                  <ToolButton
+                    id='export-teacher-button'
+                    size='small'
+                    disabled={busy || !canExport}
+                    onClick={onExport}
+                  >
+                    <IconifyIcon icon='tabler:database-export' width={18} />
+                  </ToolButton>
+                </ToolButtonSlot>
+              </Tooltip>
+            </Box>
+
+            <Button
+              id='add-teacher-button'
+              variant='contained'
+              disableElevation
+              onClick={toggle}
+              startIcon={<IconifyIcon icon='tabler:user-plus' />}
+              sx={{
+                borderRadius: 2.5,
+                whiteSpace: 'nowrap',
+                px: 3,
+                py: 1,
+                minHeight: 40,
+                width: { xs: '100%', sm: 'auto' },
+                boxShadow: (theme) => `0 8px 18px ${alpha(theme.palette.primary.main, 0.24)}`,
+                '&:hover': {
+                  boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.3)}`,
+                },
+              }}
+            >
+              เพิ่มครู / บุคลากร
+            </Button>
+          </Stack>
+        </Stack>
+      </SectionBox>
     </Box>
   );
 };

--- a/frontend/src/views/apps/teacher/list/TableHeader.tsx
+++ b/frontend/src/views/apps/teacher/list/TableHeader.tsx
@@ -2,12 +2,11 @@
 
 import IconifyIcon from '@/@core/components/icon';
 import { SectionBox } from '@/@core/components/filter-panel';
+import { AppSearchTextField, AppContainedButton } from '@/@core/components/form';
 import { ToolButton, ToolButtonSlot, ToolDivider } from '@/@core/components/toolbar';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import { alpha } from '@mui/material/styles';
 
@@ -52,7 +51,7 @@ const TableHeader = ({
             gap: { xs: 1.75, sm: 2 },
           }}
         >
-          <TextField
+          <AppSearchTextField
             id='teacher-search-input'
             size='small'
             value={value}
@@ -70,25 +69,6 @@ const TableHeader = ({
             sx={{
               width: { xs: '100%', md: 360 },
               flex: { xs: '1 1 auto', md: '0 1 360px' },
-              '& .MuiOutlinedInput-root': {
-                borderRadius: 2.5,
-                backgroundColor: (theme) =>
-                  alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.9 : 0.96),
-                transition: 'border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
-                '& .MuiInputAdornment-root': { color: 'primary.main' },
-                '& fieldset': {
-                  borderColor: (theme) =>
-                    alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.16),
-                },
-                '&:hover fieldset': {
-                  borderColor: (theme) => alpha(theme.palette.primary.main, 0.38),
-                },
-                '&.Mui-focused': {
-                  backgroundColor: 'background.paper',
-                  boxShadow: (theme) => `0 0 0 3px ${alpha(theme.palette.primary.main, 0.1)}`,
-                },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-              },
             }}
           />
 
@@ -168,27 +148,16 @@ const TableHeader = ({
               </Tooltip>
             </Box>
 
-            <Button
+            <AppContainedButton
               id='add-teacher-button'
               variant='contained'
               disableElevation
               onClick={toggle}
               startIcon={<IconifyIcon icon='tabler:user-plus' />}
-              sx={{
-                borderRadius: 2.5,
-                whiteSpace: 'nowrap',
-                px: 3,
-                py: 1,
-                minHeight: 40,
-                width: { xs: '100%', sm: 'auto' },
-                boxShadow: (theme) => `0 8px 18px ${alpha(theme.palette.primary.main, 0.24)}`,
-                '&:hover': {
-                  boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.3)}`,
-                },
-              }}
+              sx={{ width: { xs: '100%', sm: 'auto' } }}
             >
               เพิ่มครู / บุคลากร
-            </Button>
+            </AppContainedButton>
           </Stack>
         </Stack>
       </SectionBox>

--- a/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
+++ b/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
@@ -1,26 +1,23 @@
 'use client';
 
-import {
-  Alert,
-  AlertTitle,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-  useTheme,
-} from '@mui/material';
-import { alpha, styled } from '@mui/material/styles';
-import { HumanMaleBoard } from 'mdi-material-ui';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { HumanMaleBoard } from 'mdi-material-ui';
 import React, { Fragment, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { useResponsive } from '@/@core/hooks/useResponsive';
-import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { AppTeacherDataGrid } from '@/@core/components/data-grid/AppListDataGrid';
 import { AppListCard, AppListCardHeader, type ListSummaryItem } from '@/@core/components/list-page';
 import { toast } from 'react-toastify';
 
@@ -39,36 +36,6 @@ import { PAGE_SIZE_OPTIONS } from '@/views/apps/teacher/list/constants';
 import httpClient from '@/@core/utils/http';
 import { authConfig } from '@/configs/auth';
 import { useImportTeachers, type TeacherImportResult } from '@/hooks/queries';
-
-const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
-  '& .MuiDataGrid-row': {
-    '&:nth-of-type(even)': {
-      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.035 : 0.02),
-    },
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.12 : 0.055),
-    },
-  },
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08),
-    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.14)}`,
-    borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.22)}`,
-  },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontSize: '0.8rem',
-    letterSpacing: '0.02em',
-  },
-  '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-  '& .MuiDataGrid-cell[data-field="fullName"]': {
-    paddingLeft: theme.spacing(3),
-    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
-    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
-  },
-}));
 
 const getErrorMessage = (error: any, fallback: string) => {
   if (typeof error?.response?.data?.message === 'string') {
@@ -397,7 +364,7 @@ const TeacherListPage = () => {
                 id='teacher-data-grid-container'
                 sx={{ '& .MuiDataGrid-root': { minHeight: 440 } }}
               >
-                <StyledDataGrid
+                <AppTeacherDataGrid
                   disableColumnMenu
                   rows={teachers}
                   loading={isLoadingTeachers}
@@ -484,8 +451,8 @@ const TeacherListPage = () => {
           />
         </Box>
       )}
-      <Dialog open={isImportResultOpen} fullWidth maxWidth='sm' onClose={() => setIsImportResultOpen(false)}>
-        <DialogTitle>ผลการนำเข้าข้อมูลครูและบุคลากร</DialogTitle>
+      <Dialog id='teacher-import-result-dialog' open={isImportResultOpen} fullWidth maxWidth='sm' aria-labelledby='teacher-import-result-title' onClose={() => setIsImportResultOpen(false)}>
+        <DialogTitle id='teacher-import-result-title'>ผลการนำเข้าข้อมูลครูและบุคลากร</DialogTitle>
         <DialogContent>
           {importResult && (
             <>
@@ -562,12 +529,12 @@ const TeacherListPage = () => {
           )}
         </DialogContent>
         <DialogActions sx={{ px: 6, pb: 5, pt: 1 }}>
-          <Button variant='contained' onClick={() => setIsImportResultOpen(false)}>
+          <Button id='teacher-import-result-close-button' variant='contained' onClick={() => setIsImportResultOpen(false)}>
             ปิด
           </Button>
         </DialogActions>
       </Dialog>
-      <input ref={fileInputRef} hidden type='file' accept='.xlsx' onChange={handleImportFile} />
+      <input id='teacher-import-file-input' ref={fileInputRef} hidden type='file' accept='.xlsx' onChange={handleImportFile} />
     </Fragment>
   );
 };

--- a/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
+++ b/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
@@ -298,6 +298,7 @@ const TeacherListPage = () => {
             }}
           >
             <CardHeader
+              id='teacher-list-card-header'
               avatar={
                 <Avatar
                   sx={{
@@ -617,6 +618,18 @@ const TeacherListPage = () => {
                     },
                     '& .MuiDataGrid-renderingZone': {
                       maxHeight: 'none !important',
+                    },
+                    '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
+                      pl: { xs: 3, sm: 4, lg: 5 },
+                    },
+                    '& .MuiDataGrid-columnHeader[data-field="actions"]': {
+                      pr: { xs: 3, sm: 4, lg: 5 },
+                    },
+                    '& .MuiDataGrid-cell[data-field="fullName"]': {
+                      pl: { xs: 3, sm: 4, lg: 5 },
+                    },
+                    '& .MuiDataGrid-cell[data-field="actions"]': {
+                      pr: { xs: 3, sm: 4, lg: 5 },
                     },
                   }}
                 />

--- a/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
+++ b/frontend/src/views/apps/teacher/list/TeacherListPage.tsx
@@ -3,11 +3,8 @@
 import {
   Alert,
   AlertTitle,
-  Avatar,
   Box,
   Button,
-  Card,
-  CardHeader,
   Dialog,
   DialogActions,
   DialogContent,
@@ -18,12 +15,13 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import { HumanMaleBoard } from 'mdi-material-ui';
 import Grid from '@mui/material/Grid';
 import React, { Fragment, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { useResponsive } from '@/@core/hooks/useResponsive';
-import { DataGrid } from '@mui/x-data-grid';
+import AppDataGrid from '@/@core/components/data-grid/AppDataGrid';
+import { AppListCard, AppListCardHeader, type ListSummaryItem } from '@/@core/components/list-page';
 import { toast } from 'react-toastify';
 
 import AddTeacherDrawer from '@/views/apps/teacher/list/AddUserDrawer';
@@ -41,6 +39,36 @@ import { PAGE_SIZE_OPTIONS } from '@/views/apps/teacher/list/constants';
 import httpClient from '@/@core/utils/http';
 import { authConfig } from '@/configs/auth';
 import { useImportTeachers, type TeacherImportResult } from '@/hooks/queries';
+
+const StyledDataGrid = styled(AppDataGrid)(({ theme }) => ({
+  '& .MuiDataGrid-row': {
+    '&:nth-of-type(even)': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.035 : 0.02),
+    },
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.12 : 0.055),
+    },
+  },
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.14)}`,
+    borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+  },
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontSize: '0.8rem',
+    letterSpacing: '0.02em',
+  },
+  '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+  '& .MuiDataGrid-cell[data-field="fullName"]': {
+    paddingLeft: theme.spacing(3),
+    [theme.breakpoints.up('sm')]: { paddingLeft: theme.spacing(4) },
+    [theme.breakpoints.up('lg')]: { paddingLeft: theme.spacing(5) },
+  },
+}));
 
 const getErrorMessage = (error: any, fallback: string) => {
   if (typeof error?.response?.data?.message === 'string') {
@@ -85,8 +113,6 @@ const formatExportBirthDate = (value?: Date | string | null) => {
 
   return date.toISOString().slice(0, 10);
 };
-
-type TeacherSummaryColor = 'success' | 'primary' | 'warning';
 
 const TeacherListPage = () => {
   const { isMobile, isTablet } = useResponsive();
@@ -144,14 +170,14 @@ const TeacherListPage = () => {
     [teachers],
   );
   const importToolIsBusy = isDownloadingTemplate || isExporting || isImporting;
-  const teacherSummaryItems = useMemo(
+  const teacherSummaryItems = useMemo<ListSummaryItem[]>(
     () => [
-      { label: 'เปิดใช้งาน', value: activeTeacherCount, color: 'success' as TeacherSummaryColor },
-      { label: 'มีห้องที่ปรึกษา', value: classroomAssignedCount, color: 'primary' as TeacherSummaryColor },
+      { label: 'เปิดใช้งาน', value: activeTeacherCount, color: 'success' },
+      { label: 'มีห้องที่ปรึกษา', value: classroomAssignedCount, color: 'primary' },
       {
         label: importToolIsBusy ? 'กำลังประมวลผลไฟล์' : 'พร้อมนำเข้าไฟล์',
         value: importToolIsBusy ? '...' : '.xlsx',
-        color: 'warning' as TeacherSummaryColor,
+        color: 'warning',
       },
     ],
     [activeTeacherCount, classroomAssignedCount, importToolIsBusy],
@@ -282,186 +308,15 @@ const TeacherListPage = () => {
     <Fragment>
       <Grid container spacing={{ xs: 3, md: 5 }} id='teacher-list-container'>
         <Grid size={12}>
-          <Card
-            id='teacher-list-card'
-            sx={{
-              overflow: 'hidden',
-              border: (theme) => `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.22 : 0.12)}`,
-              background: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.1)} 0%, ${alpha(theme.palette.background.paper, 0.98)} 32%)`
-                  : `linear-gradient(180deg, ${alpha(theme.palette.primary.main, 0.05)} 0%, ${theme.palette.background.paper} 32%)`,
-              boxShadow: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? `0 18px 42px ${alpha(theme.palette.common.black, 0.24)}`
-                  : `0 18px 42px ${alpha(theme.palette.primary.main, 0.08)}`,
-            }}
-          >
-            <CardHeader
+          <AppListCard id='teacher-list-card'>
+            <AppListCardHeader
               id='teacher-list-card-header'
-              avatar={
-                <Avatar
-                  sx={{
-                    color: (theme) => theme.palette.primary.dark,
-                    bgcolor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.18 : 0.12),
-                    border: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
-                    width: { xs: 42, sm: 48 },
-                    height: { xs: 42, sm: 48 },
-                    boxShadow: (theme) => `0 10px 24px ${alpha(theme.palette.primary.main, 0.16)}`,
-                  }}
-                >
-                  <HumanMaleBoard />
-                </Avatar>
-              }
-              sx={{
-                color: 'text.primary',
-                alignItems: 'flex-start',
-                px: { xs: 3, sm: 4, lg: 5 },
-                pt: { xs: 3, sm: 4.25 },
-                pb: { xs: 2.5, sm: 3 },
-                background: (theme) =>
-                  theme.palette.mode === 'dark'
-                    ? alpha(theme.palette.primary.main, 0.07)
-                    : alpha(theme.palette.primary.main, 0.03),
-                '& .MuiCardHeader-avatar': {
-                  mt: 0.25,
-                  mr: { xs: 2, sm: 2.5 },
-                },
-                '& .MuiCardHeader-content': {
-                  minWidth: 0,
-                },
-              }}
-              title={
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: { xs: 'flex-start', sm: 'center' },
-                    flexDirection: { xs: 'column', sm: 'row' },
-                    flexWrap: 'wrap',
-                    columnGap: { xs: 1, sm: 1.5 },
-                    rowGap: 0.75,
-                  }}
-                >
-                  <Typography
-                    component='span'
-                    sx={{
-                      fontWeight: 800,
-                      fontSize: { xs: '1.45rem', sm: '1.9rem' },
-                      letterSpacing: { xs: '-0.02em', sm: '-0.03em' },
-                      lineHeight: 1.08,
-                      color: 'text.primary',
-                    }}
-                  >
-                    ครู / บุคลากร
-                  </Typography>
-                  {teachers.length > 0 && (
-                    <Box
-                      component='span'
-                      sx={{
-                        display: 'inline-flex',
-                        alignItems: 'baseline',
-                        gap: 0.75,
-                        px: 1.4,
-                        py: 0.6,
-                        borderRadius: 999,
-                        bgcolor: (theme) =>
-                          alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
-                        border: (theme) =>
-                          `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.12)}`,
-                        color: 'primary.main',
-                        lineHeight: 1,
-                      }}
-                    >
-                      <Typography
-                        component='span'
-                        sx={{
-                          fontSize: { xs: '1.05rem', sm: '1.15rem' },
-                          fontWeight: 800,
-                          letterSpacing: '-0.02em',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
-                      >
-                        {teachers.length.toLocaleString('th-TH')}
-                      </Typography>
-                      <Typography
-                        component='span'
-                        sx={{ fontSize: '0.9rem', fontWeight: 700, letterSpacing: '0.01em', color: 'text.secondary' }}
-                      >
-                        คน
-                      </Typography>
-                    </Box>
-                  )}
-                </Box>
-              }
-              subheader={
-                <Box>
-                  <Typography
-                    component='p'
-                    sx={{
-                      mt: 1.1,
-                      fontSize: 'clamp(0.98rem, 0.94rem + 0.16vw, 1.06rem)',
-                      fontWeight: 500,
-                      letterSpacing: '-0.01em',
-                      color: 'text.secondary',
-                    }}
-                  >
-                    ค้นหา จัดการ และนำเข้าข้อมูลครู/บุคลากรได้จากแผงเดียว
-                  </Typography>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: { xs: 0.75, sm: 1 },
-                      mt: 2.25,
-                      maxWidth: 760,
-                    }}
-                  >
-                    {teacherSummaryItems.map((item) => (
-                      <Box
-                        key={item.label}
-                        component='span'
-                        sx={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          gap: 0.75,
-                          px: 1.35,
-                          py: 0.7,
-                          minHeight: 30,
-                          borderRadius: 999,
-                          border: (theme) =>
-                            `1px solid ${alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.26 : 0.18)}`,
-                          bgcolor: (theme) =>
-                            alpha(theme.palette[item.color].main, theme.palette.mode === 'dark' ? 0.11 : 0.075),
-                        }}
-                      >
-                        <Typography
-                          component='span'
-                          sx={{
-                            fontSize: '0.8rem',
-                            fontWeight: 800,
-                            lineHeight: 1,
-                            color: `${item.color}.dark`,
-                            fontVariantNumeric: 'tabular-nums',
-                          }}
-                        >
-                          {typeof item.value === 'number' ? item.value.toLocaleString('th-TH') : item.value}
-                        </Typography>
-                        <Typography
-                          component='span'
-                          sx={{ fontSize: '0.78rem', fontWeight: 700, lineHeight: 1, color: 'text.secondary' }}
-                        >
-                          {item.label}
-                        </Typography>
-                      </Box>
-                    ))}
-                  </Box>
-                </Box>
-              }
-              slotProps={{
-                subheader: {
-                  component: 'div',
-                },
-              }}
+              icon={<HumanMaleBoard />}
+              title='ครู / บุคลากร'
+              count={teachers.length}
+              countUnit='คน'
+              description='ค้นหา จัดการ และนำเข้าข้อมูลครู/บุคลากรได้จากแผงเดียว'
+              summaryItems={teacherSummaryItems}
             />
             <TableHeader
               value={searchValue}
@@ -540,19 +395,14 @@ const TeacherListPage = () => {
             ) : (
               <Box
                 id='teacher-data-grid-container'
-                sx={{
-                  px: { md: 0 },
-                  '& .MuiDataGrid-root': {
-                    minHeight: 440,
-                  },
-                }}
+                sx={{ '& .MuiDataGrid-root': { minHeight: 440 } }}
               >
-                <DataGrid
+                <StyledDataGrid
                   disableColumnMenu
                   rows={teachers}
                   loading={isLoadingTeachers}
                   getRowHeight={() => 'auto'}
-                  columns={columns}
+                  columns={columns as any}
                   initialState={{
                     pagination: {
                       paginationModel: { pageSize, page: 0 },
@@ -561,9 +411,7 @@ const TeacherListPage = () => {
                   pageSizeOptions={PAGE_SIZE_OPTIONS}
                   onPaginationModelChange={(model) => setPageSize(model.pageSize)}
                   disableRowSelectionOnClick
-                  localeText={{
-                    noRowsLabel: 'ไม่มีข้อมูล',
-                  }}
+                  localeText={{ noRowsLabel: 'ไม่มีข้อมูล' }}
                   slotProps={{
                     pagination: {
                       labelRowsPerPage: 'แถวต่อหน้า',
@@ -572,37 +420,7 @@ const TeacherListPage = () => {
                     },
                   }}
                   sx={{
-                    border: 0,
-                    backgroundColor: 'transparent',
-                    '& .MuiDataGrid-row': {
-                      transition: 'background-color 180ms ease',
-                      '&:nth-of-type(even)': {
-                        backgroundColor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.035 : 0.02),
-                      },
-                      '&:hover': {
-                        backgroundColor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.12 : 0.055),
-                      },
-                      maxHeight: 'none !important',
-                    },
-                    '& .MuiDataGrid-columnHeaders': {
-                      backgroundColor: (theme) => alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08),
-                      borderTop: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.14)}`,
-                      borderBottom: (theme) => `2px solid ${alpha(theme.palette.primary.main, 0.22)}`,
-                    },
-                    '& .MuiDataGrid-columnHeaderTitle': {
-                      color: 'text.primary',
-                      fontWeight: 700,
-                      fontSize: '0.8rem',
-                      letterSpacing: '0.02em',
-                    },
                     '& .MuiDataGrid-cell': {
-                      display: 'flex',
-                      alignItems: 'center',
-                      lineHeight: 'unset !important',
-                      maxHeight: 'none !important',
-                      overflow: 'visible',
-                      whiteSpace: 'normal',
-                      wordWrap: 'break-word',
                       fontSize: isTablet ? '0.8rem' : '0.875rem',
                       px: isTablet ? 1.5 : 2.5,
                       py: isTablet ? 1.25 : 2,
@@ -612,30 +430,11 @@ const TeacherListPage = () => {
                       px: isTablet ? 1.5 : 2.5,
                       py: 1.5,
                     },
-                    '& .MuiDataGrid-footerContainer': {
-                      borderTop: (theme) => `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
-                      backgroundColor: (theme) => alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.74),
-                    },
-                    '& .MuiDataGrid-renderingZone': {
-                      maxHeight: 'none !important',
-                    },
-                    '& .MuiDataGrid-columnHeader[data-field="fullName"]': {
-                      pl: { xs: 3, sm: 4, lg: 5 },
-                    },
-                    '& .MuiDataGrid-columnHeader[data-field="actions"]': {
-                      pr: { xs: 3, sm: 4, lg: 5 },
-                    },
-                    '& .MuiDataGrid-cell[data-field="fullName"]': {
-                      pl: { xs: 3, sm: 4, lg: 5 },
-                    },
-                    '& .MuiDataGrid-cell[data-field="actions"]': {
-                      pr: { xs: 3, sm: 4, lg: 5 },
-                    },
                   }}
                 />
               </Box>
             )}
-          </Card>
+          </AppListCard>
         </Grid>
         {addUserOpen && (
           <AddTeacherDrawer


### PR DESCRIPTION
## Summary

- Add `NavMenuText` shared component that uses `ResizeObserver` to detect text overflow
- On hover, overflowing titles slide left smoothly (1.5s ease-in-out) to reveal full text, then return on mouse-out
- Applied to both `VerticalNavLink` and `VerticalNavGroup`
- No visual change for titles that fit within the sidebar width

## Test plan

- [ ] Hover over long menu items (e.g. บันทึกพฤติกรรมที่ไม่เหมาะสม, เช็คชื่อกิจกรรม-ผู้ดูแลระบบ) — text should scroll left
- [ ] Hover out — text should slide back to original position
- [ ] Short menu titles — no scroll effect
- [ ] Collapsed sidebar — no effect (text hidden)
- [ ] Collapsed + hover (expanded) — scroll detection recalculates via ResizeObserver