### PR TITLE
feat: teacher scoped classroom creation + fix profile save flow

### DIFF
--- a/backend-elysia/src/__tests__/classrooms.routes.test.ts
+++ b/backend-elysia/src/__tests__/classrooms.routes.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+process.env.JWT_SECRET = "test-jwt-secret-minimum-32-chars!!";
+
+// --- Prisma mocks ---
+const mockUserFindUnique = mock();
+const mockTeacherFindUnique = mock();
+const mockProgramFindUnique = mock();
+const mockClassroomFindFirst = mock();
+const mockClassroomCreate = mock();
+const mockTeacherOnClassroomCreate = mock();
+const mockTeacherOnClassroomFindUnique = mock();
+const mockClassroomFindMany = mock();
+
+mock.module("@/libs/prisma", () => ({
+  prisma: {
+    user: { findUnique: mockUserFindUnique },
+    teacher: { findUnique: mockTeacherFindUnique },
+    program: { findUnique: mockProgramFindUnique },
+    classroom: {
+      findFirst: mockClassroomFindFirst,
+      create: mockClassroomCreate,
+      findMany: mockClassroomFindMany,
+    },
+    teacherOnClassroom: {
+      create: mockTeacherOnClassroomCreate,
+      findUnique: mockTeacherOnClassroomFindUnique,
+    },
+    department: { findUnique: mock().mockResolvedValue({ id: "dept-1" }) },
+    level: { findUnique: mock().mockResolvedValue({ id: "level-1" }) },
+  },
+}));
+
+mock.module("@/infrastructure/logging", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}));
+
+const { Elysia } = await import("elysia");
+const { jwt } = await import("@elysiajs/jwt");
+const { authGuard } = await import("@/middleware/auth");
+const { errorHandler } = await import("@/plugins/error-handler");
+const { classrooms } = await import("@/modules/classrooms");
+
+const testApp = new Elysia().use(errorHandler).use(classrooms);
+
+async function signToken(payload: Record<string, unknown>): Promise<string> {
+  const res = await new Elysia()
+    .use(jwt({ name: "jwt", secret: process.env.JWT_SECRET! }))
+    .get("/sign", ({ jwt }: { jwt: { sign: (p: unknown) => Promise<string> } }) =>
+      jwt.sign(payload),
+    )
+    .handle(new Request("http://localhost/sign"));
+  return res.text();
+}
+
+const CLASSROOM_RESPONSE = {
+  id: "cls-1",
+  classroomId: "CR001",
+  name: "ปวช.1/1-ช่างไฟฟ้า",
+  departmentId: "dept-1",
+  programId: "prog-1",
+  levelId: "level-1",
+  description: null,
+  status: "active",
+  teacherIds: [],
+  levelClassroomIds: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  createdBy: "user-teacher-1",
+  updatedBy: "user-teacher-1",
+  program: null,
+  department: null,
+  level: null,
+  levelClassrooms: [],
+  _count: { student: 0, teachers: 0, course: 0, reportCheckIn: 0, activityCheckInReport: 0, levelClassrooms: 0 },
+};
+
+describe("POST /classrooms — Admin role", () => {
+  beforeEach(() => {
+    mockUserFindUnique.mockReset();
+    mockClassroomFindFirst.mockReset();
+    mockClassroomCreate.mockReset();
+  });
+
+  it("creates classroom when Admin", async () => {
+    const token = await signToken({ sub: "admin-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "admin-1", username: "admin", role: "Admin", status: "active" });
+    mockClassroomFindFirst.mockResolvedValue(null);
+    mockClassroomCreate.mockResolvedValue(CLASSROOM_RESPONSE);
+
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR001", name: "ปวช.1/1-ช่างไฟฟ้า", departmentId: "dept-1" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 401 when no token", async () => {
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR001", name: "test" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /classrooms — Teacher role (scoped creation)", () => {
+  beforeEach(() => {
+    mockUserFindUnique.mockReset();
+    mockTeacherFindUnique.mockReset();
+    mockProgramFindUnique.mockReset();
+    mockClassroomFindFirst.mockReset();
+    mockClassroomCreate.mockReset();
+    mockTeacherOnClassroomCreate.mockReset();
+  });
+
+  it("creates classroom scoped to teacher department + auto-assigns advisor", async () => {
+    const token = await signToken({ sub: "user-teacher-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "user-teacher-1", username: "teacher1", role: "Teacher", status: "active" });
+    mockTeacherFindUnique.mockResolvedValue({ id: "teacher-1", departmentId: "dept-1" });
+    mockClassroomFindFirst.mockResolvedValue(null);
+    mockClassroomCreate.mockResolvedValue(CLASSROOM_RESPONSE);
+    mockTeacherOnClassroomCreate.mockResolvedValue({});
+
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR001", name: "ปวช.1/1-ช่างไฟฟ้า" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    expect(mockTeacherOnClassroomCreate).toHaveBeenCalledTimes(1);
+    const assignCall = mockTeacherOnClassroomCreate.mock.calls[0][0];
+    expect(assignCall.data.teacherId).toBe("teacher-1");
+    expect(assignCall.data.classroomId).toBe("cls-1");
+  });
+
+  it("ignores departmentId in body — uses teacher's own department", async () => {
+    const token = await signToken({ sub: "user-teacher-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "user-teacher-1", username: "teacher1", role: "Teacher", status: "active" });
+    mockTeacherFindUnique.mockResolvedValue({ id: "teacher-1", departmentId: "dept-1" });
+    mockClassroomFindFirst.mockResolvedValue(null);
+    mockClassroomCreate.mockResolvedValue(CLASSROOM_RESPONSE);
+    mockTeacherOnClassroomCreate.mockResolvedValue({});
+
+    await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR001", name: "ปวช.1/1-ช่างไฟฟ้า", departmentId: "dept-HACKED" }),
+      }),
+    );
+
+    const createCall = mockClassroomCreate.mock.calls[0][0];
+    expect(createCall.data.departmentId).toBe("dept-1");
+  });
+
+  it("returns 403 when teacher has no teacher record", async () => {
+    const token = await signToken({ sub: "user-ghost" });
+    mockUserFindUnique.mockResolvedValue({ id: "user-ghost", username: "ghost", role: "Teacher", status: "active" });
+    mockTeacherFindUnique.mockResolvedValue(null);
+
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR002", name: "test" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when programId not in teacher department", async () => {
+    const token = await signToken({ sub: "user-teacher-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "user-teacher-1", username: "teacher1", role: "Teacher", status: "active" });
+    mockTeacherFindUnique.mockResolvedValue({ id: "teacher-1", departmentId: "dept-1" });
+    mockProgramFindUnique.mockResolvedValue({ departmentId: "dept-OTHER" });
+
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ classroomId: "CR001", name: "test", programId: "prog-other" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /classrooms/:id — Teacher role (own classroom only)", () => {
+  beforeEach(() => {
+    mockUserFindUnique.mockReset();
+    mockTeacherFindUnique.mockReset();
+    mockTeacherOnClassroomFindUnique.mockReset();
+  });
+
+  it("returns 403 when teacher tries to update another teacher's classroom", async () => {
+    const token = await signToken({ sub: "user-teacher-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "user-teacher-1", username: "teacher1", role: "Teacher", status: "active" });
+    mockTeacherFindUnique.mockResolvedValue({ id: "teacher-1" });
+    mockTeacherOnClassroomFindUnique.mockResolvedValue(null);
+
+    const res = await testApp.handle(
+      new Request("http://localhost/classrooms/cls-OTHER", {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "hacked name" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend-elysia/src/modules/classrooms/index.ts
+++ b/backend-elysia/src/modules/classrooms/index.ts
@@ -29,20 +29,32 @@ export const classrooms = new Elysia({ prefix: "/classrooms" })
         .post(
           "/",
           async ({ body, user, set }) => {
-            if ((user as any)?.roles !== "Admin") {
-              throw new ForbiddenError();
+            const role = (user as any)?.roles;
+            const userId = (user as any).sub;
+            if (role === "Admin") {
+              const classroom = await ClassroomService.create({
+                ...(body as ClassroomModel["body"]),
+                createdBy: userId,
+              });
+              set.status = 201;
+              return classroom;
             }
-            const classroom = await ClassroomService.create({
-              ...(body as ClassroomModel["body"]),
-              createdBy: (user as any).sub,
-            });
-            set.status = 201;
-            return classroom;
+            if (role === "Teacher") {
+              const { departmentId: _ignored, ...teacherBody } =
+                body as ClassroomModel["body"] & { departmentId?: string };
+              const classroom = await ClassroomService.createAsTeacher(
+                userId,
+                teacherBody,
+              );
+              set.status = 201;
+              return classroom;
+            }
+            throw new ForbiddenError();
           },
           {
             body: ClassroomModel.body,
             detail: {
-              summary: "Create a new classroom",
+              summary: "Create classroom (Admin: full, Teacher: scoped to own department)",
             },
           },
         )
@@ -60,18 +72,22 @@ export const classrooms = new Elysia({ prefix: "/classrooms" })
         .patch(
           "/:id",
           async ({ params: { id }, body, user }) => {
-            if ((user as any)?.roles !== "Admin") {
+            const role = (user as any)?.roles;
+            const userId = (user as any).sub;
+            if (role === "Teacher") {
+              await ClassroomService.validateTeacherOwnsClassroom(userId, id);
+            } else if (role !== "Admin") {
               throw new ForbiddenError();
             }
             return ClassroomService.update(id, {
               ...(body as ClassroomModel["partial"]),
-              updatedBy: (user as any).sub,
+              updatedBy: userId,
             });
           },
           {
             body: ClassroomModel.partial,
             detail: {
-              summary: "Update a classroom",
+              summary: "Update classroom (Admin: any, Teacher: own classrooms only)",
             },
           },
         )

--- a/backend-elysia/src/modules/classrooms/service.ts
+++ b/backend-elysia/src/modules/classrooms/service.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/libs/prisma";
 import { classroomInclude } from "./model";
 import * as XLSX from "xlsx";
-import { BadRequestError, ConflictError, NotFoundError } from "@/libs/errors";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "@/libs/errors";
 
 export abstract class ClassroomService {
   static async getAll() {
@@ -33,6 +33,87 @@ export abstract class ClassroomService {
       },
       include: classroomInclude,
     });
+  }
+
+  static async createAsTeacher(
+    userId: string,
+    data: {
+      classroomId: string;
+      name: string;
+      description?: string;
+      programId?: string;
+      levelId?: string;
+      status?: string;
+    },
+  ) {
+    const teacher = await prisma.teacher.findUnique({
+      where: { userId },
+      select: { id: true, departmentId: true },
+    });
+    if (!teacher) {
+      throw new ForbiddenError();
+    }
+
+    if (data.programId) {
+      const program = await prisma.program.findUnique({
+        where: { id: data.programId },
+        select: { departmentId: true },
+      });
+      if (!program || program.departmentId !== teacher.departmentId) {
+        throw new BadRequestError(
+          "สาขาวิชาต้องอยู่ในแผนกของครู",
+          "programId",
+        );
+      }
+    }
+
+    const payload = await this.normalizePayload(
+      { ...data, departmentId: teacher.departmentId ?? undefined },
+      { requireClassroomId: true },
+    );
+    await this.ensureUnique(payload);
+
+    const classroom = await prisma.classroom.create({
+      data: {
+        ...payload,
+        createdBy: userId,
+        updatedBy: userId,
+      },
+      include: classroomInclude,
+    });
+
+    await prisma.teacherOnClassroom.create({
+      data: {
+        teacherId: teacher.id,
+        classroomId: classroom.id,
+        createdBy: userId,
+        updatedBy: userId,
+      },
+    });
+
+    return classroom;
+  }
+
+  static async validateTeacherOwnsClassroom(
+    userId: string,
+    classroomId: string,
+  ) {
+    const teacher = await prisma.teacher.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+    if (!teacher) throw new ForbiddenError();
+
+    const assignment = await prisma.teacherOnClassroom.findUnique({
+      where: {
+        teacherOnClassroomKey: {
+          teacherId: teacher.id,
+          classroomId,
+        },
+      },
+      select: { classroomId: true },
+    });
+    if (!assignment) throw new ForbiddenError();
   }
 
   static async getById(id: string) {

--- a/backend-elysia/src/modules/teachers/model.ts
+++ b/backend-elysia/src/modules/teachers/model.ts
@@ -41,19 +41,21 @@ export const TeacherModel = {
     }),
     teacher: t.Object({
       id: t.String(),
-      firstName: t.Optional(t.String()),
-      lastName: t.Optional(t.String()),
-      title: t.Optional(t.String()),
-      idCard: t.Optional(t.String()),
-      birthDate: t.Optional(t.Union([t.String(), t.Null()])),
       jobTitle: t.Optional(t.String()),
+      academicStanding: t.Optional(t.String()),
+      departmentId: t.Optional(t.String()),
       status: t.Optional(t.String()),
     }),
-    account: t.Optional(
-      t.Object({
-        id: t.Optional(t.String()),
-      }),
-    ),
+    account: t.Object({
+      id: t.Optional(t.String()),
+      title: t.Optional(t.String()),
+      firstName: t.Optional(t.String()),
+      lastName: t.Optional(t.String()),
+      birthDate: t.Optional(t.Union([t.String(), t.Null()])),
+      idCard: t.Optional(t.String()),
+      avatar: t.Optional(t.Union([t.String(), t.Null()])),
+    }),
+    classrooms: t.Optional(t.Array(t.String())),
   }),
 } as const;
 

--- a/backend-elysia/src/modules/teachers/service.ts
+++ b/backend-elysia/src/modules/teachers/service.ts
@@ -199,26 +199,42 @@ export abstract class TeacherService {
   static async updateProfile(id: string, data: any) {
     log.info("[TeacherService] updateProfile", { id });
 
+    const { teacher: teacherData, account: accountData, classrooms } = data as {
+      teacher: { id: string; jobTitle?: string; academicStanding?: string; departmentId?: string; status?: string };
+      account: { title?: string; firstName?: string; lastName?: string; birthDate?: string | null; idCard?: string; avatar?: string | null };
+      classrooms?: string[];
+    };
+
     await prisma.$transaction(async (tx) => {
-      const teacher = await tx.teacher.findUnique({
+      const existing = await tx.teacher.findUnique({
         where: { id },
         select: { userId: true },
       });
-      if (teacher?.userId) {
+
+      if (existing?.userId && accountData) {
+        const { id: _accountId, ...accountFields } = accountData as any;
         await tx.account.update({
-          where: { userId: teacher.userId },
-          data,
+          where: { userId: existing.userId },
+          data: {
+            ...accountFields,
+            birthDate: accountFields.birthDate ? new Date(accountFields.birthDate) : null,
+          },
         });
-        log.debug("[TeacherService] updateProfile - account updated", {
-          userId: teacher.userId,
-        });
+        log.debug("[TeacherService] updateProfile - account updated", { userId: existing.userId });
+      }
+
+      if (teacherData) {
+        const { id: _teacherId, ...teacherFields } = teacherData as any;
+        await tx.teacher.update({ where: { id }, data: teacherFields });
+        log.debug("[TeacherService] updateProfile - teacher updated", { id });
       }
     });
 
-    const updated = await prisma.teacher.findUnique({
-      where: { id },
-      include: teacherInclude,
-    });
+    if (classrooms !== undefined) {
+      await this.updateClassrooms(id, classrooms);
+    }
+
+    const updated = await prisma.teacher.findUnique({ where: { id }, include: teacherInclude });
     log.info("[TeacherService] updateProfile success", { id });
     return updated ? stripSensitive(updated) : null;
   }

--- a/frontend/src/store/apps/teacher/index.ts
+++ b/frontend/src/store/apps/teacher/index.ts
@@ -61,7 +61,8 @@ export const useTeacherStore = createWithEqualityFn<TeacherState>()((set) => ({
   updateProfile: async (teacher: any) => {
     set({ teacherLoading: true });
     try {
-      const { data } = await httpClient.put(`${authConfig.teacherEndpoint}/${teacher.id}/profile`, teacher);
+      const { id, ...body } = teacher;
+      const { data } = await httpClient.put(`${authConfig.teacherEndpoint}/${id}/profile`, body);
       set({ teacherLoading: false, hasErrors: false });
       return await data;
     } catch {

--- a/frontend/src/views/pages/account-settings/TabAccount.tsx
+++ b/frontend/src/views/pages/account-settings/TabAccount.tsx
@@ -37,6 +37,8 @@ import useImageCompression from '@/hooks/useImageCompression';
 import { useClassroomStore, useDepartmentStore } from '@/store/index';
 import { useTeacherStore } from '@/store/apps/teacher';
 import { useCurrentUser } from '@/hooks/queries/useAuth';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/libs/react-query/queryKeys';
 import { shallow } from 'zustand/shallow';
 import { isEmpty } from '@/@core/utils/utils';
 import { generateErrorMessages } from '@/utils/event';
@@ -75,6 +77,7 @@ const schema = z.object({
 const TabAccount = () => {
   // Hooks
   const auth = useAuth();
+  const queryClient = useQueryClient();
   const { refetch: refetchCurrentUser } = useCurrentUser();
 
   const { fetchClassroom }: any = useClassroomStore(
@@ -94,13 +97,43 @@ const TabAccount = () => {
   const { imageCompressed, handleInputImageChange, isCompressing } = useImageCompression();
   const { isLoading, image } = useImageQuery(imgSrc);
 
+  const defaultValues = {
+    title: auth?.user?.account?.title ?? '',
+    firstName: auth?.user?.account?.firstName ?? '',
+    lastName: auth?.user?.account?.lastName ?? '',
+    jobTitle: auth?.user?.teacher?.jobTitle ?? '',
+    academicStanding: auth?.user?.teacher?.academicStanding ?? '',
+    department: '',
+    teacherOnClassroom: auth?.user?.teacherOnClassroom ?? [],
+    avatar: auth?.user?.account?.avatar ?? '',
+    birthDate: auth?.user?.account?.birthDate ? new Date(auth?.user?.account?.birthDate) : null,
+    idCard: auth?.user?.account?.idCard ?? '',
+  };
+
+  const {
+    reset,
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    defaultValues,
+    mode: 'onChange',
+    resolver: zodResolver(schema),
+  });
+
   useEffect(() => {
     (async () => {
       await fetchDepartment().then(async (data: any) => {
-        setDepartmentValues(await data);
+        const departments = await data;
+        setDepartmentValues(departments);
+        const currentDeptId = auth?.user?.teacher?.department?.id ?? '';
+        const deptExists = currentDeptId
+          ? Array.isArray(departments) && departments.some((d: any) => d.id === currentDeptId)
+          : false;
+        reset((prev) => ({ ...prev, department: deptExists ? currentDeptId : '' }));
       });
     })();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (imageCompressed) {
@@ -119,31 +152,7 @@ const TabAccount = () => {
         setLoading(false);
       });
     })();
-  }, [departmentValues]);
-
-  const defaultValues = {
-    title: auth?.user?.account?.title ?? '',
-    firstName: auth?.user?.account?.firstName ?? '',
-    lastName: auth?.user?.account?.lastName ?? '',
-    jobTitle: auth?.user?.teacher?.jobTitle ?? '',
-    academicStanding: auth?.user?.teacher?.academicStanding ?? '',
-    department: auth?.user?.teacher?.department?.id ?? '',
-    teacherOnClassroom: auth?.user?.teacherOnClassroom ?? [],
-    avatar: auth?.user?.account?.avatar ?? '',
-    birthDate: auth?.user?.account?.birthDate ? new Date(auth?.user?.account?.birthDate) : null,
-    idCard: auth?.user?.account?.idCard ?? '',
-  };
-
-  const {
-    reset,
-    control,
-    handleSubmit,
-    formState: { errors },
-  } = useForm({
-    defaultValues,
-    mode: 'onChange',
-    resolver: zodResolver(schema),
-  });
+  }, [departmentValues]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onHandleChange = (event: any, value: any) => {
     event.preventDefault();
@@ -159,44 +168,40 @@ const TabAccount = () => {
     const image = imgSrc === '/images/avatars/1.png' ? data?.account?.avatar : imgSrc;
 
     const profile = {
-      id: auth?.user?.id,
-      teacherInfo: auth?.user?.teacher?.id,
-      accountId: auth?.user?.account?.id,
-      title: data.title,
-      firstName: data.firstName,
-      lastName: data.lastName,
-      jobTitle: data.jobTitle,
-      academicStanding: data.academicStanding,
-      department: data.department,
-      avatar: image ? image : null,
-      birthDate: data.birthDate === '' ? null : data.birthDate ? new Date(data.birthDate) : null,
-      idCard: data.idCard,
+      id: auth?.user?.teacher?.id,
+      user: { id: auth?.user?.id },
+      teacher: {
+        id: auth?.user?.teacher?.id,
+        jobTitle: data.jobTitle,
+        academicStanding: data.academicStanding,
+        departmentId: data.department,
+      },
+      account: {
+        id: auth?.user?.account?.id,
+        title: data.title,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        birthDate: data.birthDate === '' ? null : data.birthDate ? new Date(data.birthDate).toISOString() : null,
+        idCard: data.idCard,
+        avatar: image ? image : null,
+      },
       classrooms: classroomSelected.map((item: any) => item.id),
     };
 
-    const toastId = toast.info('กำลังบันทึกข้อมูล...', {
-      autoClose: false,
-      hideProgressBar: true,
-    });
+    const toastId = toast.loading('กำลังบันทึกข้อมูล...');
     await updateProfile(profile).then(async (res: any) => {
       if (res?.name !== 'AxiosError') {
-        toast.dismiss(toastId);
-        toast.success('บันทึกข้อมูลสำเร็จ');
-
-        // Refetch current user data
         const { data: updatedUser } = await refetchCurrentUser();
         if (updatedUser) {
           auth?.setUser(updatedUser);
           window.localStorage.setItem('userData', JSON.stringify(updatedUser));
-          setTimeout(() => {
-            location.reload();
-          }, 1000);
+          queryClient.setQueryData(queryKeys.users.current(), updatedUser);
         }
+        toast.update(toastId, { render: 'บันทึกข้อมูลสำเร็จ', type: 'success', isLoading: false, autoClose: 3000 });
       } else {
         const { data } = res?.response || {};
         const message = generateErrorMessages[data?.message] || data?.message;
-        toast.dismiss(toastId);
-        toast.error(message || 'เกิดข้อผิดพลาด');
+        toast.update(toastId, { render: message || 'เกิดข้อผิดพลาด', type: 'error', isLoading: false, autoClose: 5000 });
       }
     });
   };

--- a/frontend/src/views/pages/account-settings/TabTeacherAccount.tsx
+++ b/frontend/src/views/pages/account-settings/TabTeacherAccount.tsx
@@ -17,7 +17,10 @@ import {
 import Button, { ButtonProps } from '@mui/material/Button';
 import { Controller, useForm } from 'react-hook-form';
 import { useEffect, useState } from 'react';
-import { useClassroomStore, useDepartmentStore, useUserStore } from '@/store/index';
+import { useClassroomStore, useDepartmentStore } from '@/store/index';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCurrentUser } from '@/hooks/queries/useAuth';
+import { queryKeys } from '@/libs/react-query/queryKeys';
 
 import { FcCalendar } from 'react-icons/fc';
 import Icon from '@/@core/components/icon';
@@ -65,13 +68,9 @@ const schema = z.object({
 
 const TabTeacherAccount = () => {
   // Hooks
-  const { getMe }: any = useUserStore(
-    (state) => ({
-      getMe: state.getMe,
-    }),
-    shallow,
-  );
   const auth = useAuth();
+  const queryClient = useQueryClient();
+  const { refetch: refetchCurrentUser } = useCurrentUser();
 
   const { fetchClassroom }: any = useClassroomStore(
     (state) => ({ classroom: state.classroom, fetchClassroom: state.fetchClassroom }),
@@ -96,7 +95,7 @@ const TabTeacherAccount = () => {
     lastName: auth?.user?.account?.lastName ?? '',
     jobTitle: auth?.user?.teacher?.jobTitle ?? '',
     academicStanding: auth?.user?.teacher?.academicStanding ?? '',
-    department: auth?.user?.teacher?.department?.id ?? '',
+    department: '',
     teacherOnClassroom: auth?.user?.teacherOnClassroom ?? [],
     avatar: auth?.user?.account?.avatar ?? '',
     birthDate: auth?.user?.account?.birthDate ? new Date(auth?.user?.account?.birthDate) : null,
@@ -121,18 +120,14 @@ const TabTeacherAccount = () => {
         const departments = await fetchDepartment();
         setDepartmentValues(Array.isArray(departments) ? departments : []);
 
-        // Validate and reset department value if it doesn't exist in the loaded options
-        if (auth?.user?.teacher?.department?.id) {
-          const currentDeptId = auth.user.teacher.department.id;
-          const deptExists = Array.isArray(departments) && departments.some((dept: any) => dept.id === currentDeptId);
-          if (!deptExists) {
-            // Reset department field to empty if current department not found in options
-            reset({
-              ...defaultValues,
-              department: '',
-            });
-          }
-        }
+        const currentDeptId = auth?.user?.teacher?.department?.id ?? '';
+        const deptExists = currentDeptId
+          ? Array.isArray(departments) && departments.some((dept: any) => dept.id === currentDeptId)
+          : false;
+        reset({
+          ...defaultValues,
+          department: deptExists ? currentDeptId : '',
+        });
 
         // Load classrooms
         setLoading(true);
@@ -195,42 +190,40 @@ const TabTeacherAccount = () => {
     const image = imgSrc === '/images/avatars/1.png' ? data?.account?.avatar : imgSrc;
 
     const profile = {
-      id: auth?.user?.id,
-      teacherInfo: auth?.user?.teacher?.id,
-      accountId: auth?.user?.account?.id,
-      title: data.title,
-      firstName: data.firstName,
-      lastName: data.lastName,
-      jobTitle: data.jobTitle,
-      academicStanding: data.academicStanding,
-      department: data.department,
-      avatar: image ? image : null,
-      birthDate: data.birthDate === '' ? null : data.birthDate ? new Date(data.birthDate) : null,
-      idCard: data.idCard,
+      id: auth?.user?.teacher?.id,
+      user: { id: auth?.user?.id },
+      teacher: {
+        id: auth?.user?.teacher?.id,
+        jobTitle: data.jobTitle,
+        academicStanding: data.academicStanding,
+        departmentId: data.department,
+      },
+      account: {
+        id: auth?.user?.account?.id,
+        title: data.title,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        birthDate: data.birthDate === '' ? null : data.birthDate ? new Date(data.birthDate).toISOString() : null,
+        idCard: data.idCard,
+        avatar: image ? image : null,
+      },
       classrooms: classroomSelected.map((item: any) => item.id),
     };
 
-    const toastId = toast.info('กำลังบันทึกข้อมูล...', {
-      autoClose: false,
-      hideProgressBar: true,
-    });
+    const toastId = toast.loading('กำลังบันทึกข้อมูล...');
     await updateProfile(profile).then(async (res: any) => {
       if (res?.name !== 'AxiosError') {
-        toast.dismiss(toastId);
-        toast.success('บันทึกข้อมูลสำเร็จ');
-
-        await getMe().then(async (data: any) => {
-          auth?.setUser({ ...(await data) });
-          window.localStorage.setItem('userData', JSON.stringify(data));
-          setTimeout(() => {
-            location.reload();
-          }, 1000);
-        });
+        const { data: updatedUser } = await refetchCurrentUser();
+        if (updatedUser) {
+          auth?.setUser(updatedUser);
+          window.localStorage.setItem('userData', JSON.stringify(updatedUser));
+          queryClient.setQueryData(queryKeys.users.current(), updatedUser);
+        }
+        toast.update(toastId, { render: 'บันทึกข้อมูลสำเร็จ', type: 'success', isLoading: false, autoClose: 3000 });
       } else {
         const { data } = res?.response || {};
         const message = generateErrorMessages[data?.message] || data?.message;
-        toast.dismiss(toastId);
-        toast.error(message || 'เกิดข้อผิดพลาด');
+        toast.update(toastId, { render: message || 'เกิดข้อผิดพลาด', type: 'error', isLoading: false, autoClose: 5000 });
       }
     });
   };


### PR DESCRIPTION
## Summary

- **Scoped classroom creation for Teacher role** — Teacher can create classrooms limited to their own department; `departmentId` is forced from teacher profile (body value ignored); `programId` must belong to teacher's department; auto-assigns `TeacherOnClassroom` on create
- **Teacher PATCH guard** — Teacher can only update classrooms they advise (`validateTeacherOwnsClassroom`)
- **Fix profile save flow** — restructured payload from flat to `{ user, teacher, account, classrooms }` to match backend `updateBody` schema; service now updates all three tables in one transaction
- **Fix double notification** — replaced `toast.info` + dismiss + `toast.success` with `toast.loading` → `toast.update` in-place
- **Fix page reload** — replaced `location.reload()` with React Query `refetch` + `setQueryData`
- **Fix MUI out-of-range Select** — initialize `department: ''`, then `reset()` after `fetchDepartment` resolves

## Test plan

- [ ] Teacher role: create classroom → department auto-locked to teacher's department
- [ ] Teacher role: PATCH own classroom → allowed; PATCH other classroom → 403
- [ ] Admin role: create/update classroom → unchanged behavior
- [ ] Save account settings → single toast (loading → success/error in-place, no page reload)
- [ ] Open account settings → no MUI out-of-range warning for department Select
- [ ] Backend tests: `bun test` → 174/174 pass