### PR TITLE
ci: add GitHub Actions self-hosted runner deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run backend tests
+        run: bun run test
+        working-directory: backend-elysia
+
+  deploy:
+    name: Deploy
+    runs-on: [self-hosted, Linux, X64]
+    needs: test
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write env files
+        run: |
+          mkdir -p ./deploy/env
+          printf '%s' "$BACKEND_ENV" > ./deploy/env/backend.env
+          printf '%s' "$FRONTEND_ENV" > ./deploy/env/frontend.env
+        env:
+          BACKEND_ENV: ${{ secrets.BACKEND_ENV }}
+          FRONTEND_ENV: ${{ secrets.FRONTEND_ENV }}
+
+      - name: Deploy
+        run: ./deploy/deploy.sh x86 deploy
+
+      - name: Prune unused Docker images
+        if: always()
+        run: docker image prune -f

--- a/frontend/src/utils/resize-image.ts
+++ b/frontend/src/utils/resize-image.ts
@@ -23,7 +23,7 @@ const readFileAsDataUrl = (file: File): Promise<string> =>
 
 const loadImage = (dataUrl: string): Promise<HTMLImageElement> =>
   new Promise((resolve, reject) => {
-    const image = new Image();
+    const image = new window.Image();
     image.onload = () => resolve(image);
     image.onerror = () => reject(new Error('ไม่สามารถโหลดไฟล์รูปภาพได้'));
     image.src = dataUrl;


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow triggered on push to `main`
- Run backend tests before deploy
- Write env files from GitHub Secrets (`BACKEND_ENV`, `FRONTEND_ENV`)
- Build Docker images on self-hosted server (no registry needed)
- Prune unused Docker images after deploy to prevent disk fill

## Setup Required
Add these secrets in GitHub repo settings:
- `BACKEND_ENV` — full content of `deploy/env/backend.env`
- `FRONTEND_ENV` — full content of `deploy/env/frontend.env`

## Test plan
- [ ] Merge PR to `main`
- [ ] Verify runner picks up job
- [ ] Confirm test job passes
- [ ] Confirm deploy job completes