### PR TITLE
fix(prisma): fix PrismaPg adapter ECONNREFUSED on startup

### DIFF
--- a/backend-elysia/src/libs/prisma.ts
+++ b/backend-elysia/src/libs/prisma.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import { PrismaClient } from "../../generated/client";
 import { PrismaPg } from "@prisma/adapter-pg";
-import pg from "pg";
 import { logger } from "../infrastructure/logging/index.ts";
 
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -28,36 +27,14 @@ logger.info("🗄️ Initializing database connection", {
   database: dbInfo.database,
 });
 
-const pool = new pg.Pool({
+// Pass connection config directly to PrismaPg so it uses its own internal pg.Pool.
+// Passing an external pg.Pool fails instanceof check (different module instances) -> ECONNREFUSED.
+const adapter = new PrismaPg({
   connectionString: DATABASE_URL,
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 10000,
-  allowExitOnIdle: true,
-});
-
-// Log pool events
-pool.on("connect", () => {
-  logger.debug("Database pool: new client connected");
-});
-
-pool.on("acquire", () => {
-  logger.debug("Database pool: client acquired");
-});
-
-pool.on("release", () => {
-  logger.debug("Database pool: client released");
-});
-
-pool.on("remove", () => {
-  logger.debug("Database pool: client removed");
-});
-
-pool.on("error", (err) => {
-  logger.error("Database pool error", { error: err.message });
-});
-
-const adapter = new PrismaPg(pool as any);
+} as any);
 
 export const prisma = new PrismaClient({ 
   adapter,
@@ -123,7 +100,6 @@ process.on("beforeExit", async () => {
   logger.info("Closing database connections");
   try {
     await prisma.$disconnect();
-    await pool.end();
   } catch (error) {
     logger.error("Error during graceful shutdown", {
       error: error instanceof Error ? error.message : String(error),

--- a/frontend/src/configs/roles.ts
+++ b/frontend/src/configs/roles.ts
@@ -1,0 +1,8 @@
+export const Roles = {
+  Admin: 'Admin',
+  Teacher: 'Teacher',
+  Student: 'Student',
+  Parent: 'Parent',
+} as const;
+
+export type Role = (typeof Roles)[keyof typeof Roles];

--- a/frontend/src/hooks/useRole.ts
+++ b/frontend/src/hooks/useRole.ts
@@ -1,0 +1,15 @@
+import { useAuth } from '@/hooks/useAuth';
+import { Roles, type Role } from '@/configs/roles';
+
+export const useRole = () => {
+  const { user } = useAuth();
+  const role = user?.role as Role | undefined;
+
+  return {
+    role,
+    isAdmin: role === Roles.Admin,
+    isTeacher: role === Roles.Teacher,
+    isStudent: role === Roles.Student,
+    isParent: role === Roles.Parent,
+  };
+};

--- a/frontend/src/layouts/components/UserDropdown.tsx
+++ b/frontend/src/layouts/components/UserDropdown.tsx
@@ -15,6 +15,7 @@ import Typography from '@mui/material/Typography';
 import { getInitials } from '@/@core/utils/get-initials';
 import { styled } from '@mui/material/styles';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import useImageQuery from '@/hooks/useImageQuery';
 import { useRouter } from 'next/navigation';
 
@@ -41,6 +42,7 @@ const UserDropdown = (props: Props) => {
   // ** Hooks
   const router = useRouter();
   const { user, logout } = useAuth();
+  const { isAdmin } = useRole();
 
   // ** Vars
   const { direction } = settings;
@@ -101,7 +103,7 @@ const UserDropdown = (props: Props) => {
   };
 
   const avatarAccount = () => {
-    return user?.role === 'Admin' ? (
+    return isAdmin ? (
       <Avatar alt={user?.username} src='/images/avatars/1.png' sx={{ width: '2.5rem', height: '2.5rem' }} />
     ) : (
       customAvatar(user?.account)

--- a/frontend/src/utils/route-utils.ts
+++ b/frontend/src/utils/route-utils.ts
@@ -1,9 +1,8 @@
-/**
- * Get Home URL based on User Roles
- */
+import { Roles } from '@/configs/roles';
+
 export const getHomeRoute = (role: string): string => {
-  if (role === 'Teacher') return '/home';
-  if (role === 'Student') return '/apps/student/overview';
+  if (role === Roles.Teacher) return '/home';
+  if (role === Roles.Student) return '/apps/student/overview';
   return '/home';
 };
 

--- a/frontend/src/views/apps/record-badness/group/RecordBadnessGroupPage.tsx
+++ b/frontend/src/views/apps/record-badness/group/RecordBadnessGroupPage.tsx
@@ -11,6 +11,7 @@ import { HiThumbDown } from 'react-icons/hi';
 import Icon from '@/@core/components/icon';
 import TableHeaderGroup from '@/views/apps/record-goodness/TableHeaderGroup';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { useClassrooms, useStudentsSearch } from '@/hooks/queries';
 import { deepOrange } from '@mui/material/colors';
 import DialogAddGroup from '@/views/apps/record-badness/DialogAddGroup';
@@ -29,6 +30,7 @@ export interface DialogTitleProps {
 
 const RecordBadnessGroupPage = () => {
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
 
   const [students, setStudents] = useState<any>([]);
@@ -249,7 +251,7 @@ const RecordBadnessGroupPage = () => {
 
   return (
     ability?.can('read', 'report-badness-group-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/record-badness/individual/RecordBadnessIndividualPage.tsx
+++ b/frontend/src/views/apps/record-badness/individual/RecordBadnessIndividualPage.tsx
@@ -25,6 +25,7 @@ import {
 import { isEmpty } from '@/@core/utils/utils';
 import { styled } from '@mui/material/styles';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { useStudentsSearch } from '@/hooks/queries/useStudents';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/libs/react-query/queryKeys';
@@ -38,6 +39,7 @@ const LinkStyled = styled(Link)(({ theme }) => ({
 const RecordBadnessIndividualPage = () => {
   // ** Hooks
   const { user } = useAuth();
+  const { isAdmin } = useRole();
   const queryClient = useQueryClient();
 
   // ** State
@@ -64,10 +66,9 @@ const RecordBadnessIndividualPage = () => {
       return [];
     }
 
-    const role = user?.role?.toLowerCase();
     const teacherOnClassroom = user?.teacherOnClassroom;
 
-    if (role === 'admin') {
+    if (isAdmin) {
       return allStudents;
     }
 

--- a/frontend/src/views/apps/record-goodness/group/RecordGoodnessGroupPage.tsx
+++ b/frontend/src/views/apps/record-goodness/group/RecordGoodnessGroupPage.tsx
@@ -24,6 +24,7 @@ import {
   TablePaginationCustom,
 } from '@/@core/components/mui/table';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { useClassrooms, useStudents } from '@/hooks/queries';
 import { toast } from 'react-toastify';
 import { getStudentName, getStudentId, getStudentClassroom } from '@/utils/student';
@@ -37,6 +38,7 @@ export interface DialogTitleProps {
 const RecordGoodnessGroupPage = () => {
   // ** Hooks
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
 
   // ** Local State
@@ -194,7 +196,7 @@ const RecordGoodnessGroupPage = () => {
 
   return (
     ability?.can('read', 'report-goodness-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/reports/activity-check-in/daily/ActivityCheckInDailyReportPage.tsx
+++ b/frontend/src/views/apps/reports/activity-check-in/daily/ActivityCheckInDailyReportPage.tsx
@@ -39,6 +39,7 @@ import {
 import SidebarEditCheckInDrawer from '@/views/apps/reports/check-in/EditCheckInDrawer';
 import { shallow } from 'zustand/shallow';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import React from 'react';
 import { toApiDate } from '@/utils/datetime';
 
@@ -106,6 +107,7 @@ const DataGridCustom = styled(DataGrid)(({ theme }) => ({
 
 const ActivityCheckInDailyReportPage = () => {
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const router = useRouter();
 
@@ -175,7 +177,7 @@ const ActivityCheckInDailyReportPage = () => {
 
   // Authorization check
   useEffectOnce(() => {
-    if (!ability?.can('read', 'report-check-in-daily-page') || (auth?.user?.role as string) === 'Admin') {
+    if (!ability?.can('read', 'report-check-in-daily-page') || isAdmin) {
       router.push('/401');
       return;
     }
@@ -425,7 +427,7 @@ const ActivityCheckInDailyReportPage = () => {
 
   return (
     ability?.can('read', 'report-check-in-daily-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/reports/activity-check-in/summary/ActivityCheckInSummaryReportPage.tsx
+++ b/frontend/src/views/apps/reports/activity-check-in/summary/ActivityCheckInSummaryReportPage.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation';
 import { BsBarChartLine } from 'react-icons/bs';
 import TableHeaderSummary from '@/views/apps/reports/activity-check-in/TableHeaderSummary';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { shallow } from 'zustand/shallow';
 import { toast } from 'react-toastify';
 
@@ -27,6 +28,7 @@ const ACTIVITY_TYPES = [
 
 const ActivityCheckInSummaryReportPage = () => {
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const router = useRouter();
 
@@ -74,7 +76,7 @@ const ActivityCheckInSummaryReportPage = () => {
       });
     };
 
-    if (ability?.can('read', 'summary-check-in-report-activity-page') && auth?.user?.role !== 'Admin') {
+    if (ability?.can('read', 'summary-check-in-report-activity-page') && !isAdmin) {
       if (isEmpty(auth?.user?.teacherOnClassroom)) {
         toast.error('ไม่พบข้อมูลที่ปรีกษาประจำชั้น');
         router.push('/pages/account-settings');
@@ -261,7 +263,7 @@ const ActivityCheckInSummaryReportPage = () => {
 
   return (
     ability?.can('read', 'summary-check-in-report-activity-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/reports/badness/all/BadnessAllReportPage.tsx
+++ b/frontend/src/views/apps/reports/badness/all/BadnessAllReportPage.tsx
@@ -7,6 +7,7 @@ import { AbilityContext } from '@/layouts/components/acl/Can';
 import CloseIcon from '@mui/icons-material/Close';
 import TableHeader from '@/views/apps/reports/goodness/TableHeader';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import TimelineBadness from '@/views/apps/student/view/TimelineBadness';
 import { useBadnessReport } from './hooks/useBadnessReport';
 import { useBadnessReportColumns } from './components/BadnessReportColumns';
@@ -45,6 +46,7 @@ DialogCloseButton.displayName = 'DialogCloseButton';
 const BadnessAllReportPage = () => {
   // ** Hooks
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
@@ -103,7 +105,7 @@ const BadnessAllReportPage = () => {
 
   return (
     ability?.can('read', 'report-badness-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Box id='badness-report-page' sx={{ borderRadius: '8px', overflow: 'hidden' }}>
           <Grid id='badness-report-grid-container' container spacing={responsiveConfig.containerSpacing}>

--- a/frontend/src/views/apps/reports/badness/summary/BadnessSummaryReportPage.tsx
+++ b/frontend/src/views/apps/reports/badness/summary/BadnessSummaryReportPage.tsx
@@ -30,6 +30,7 @@ import { badnessIndividualStore } from '@/store/index';
 import { shallow } from 'zustand/shallow';
 import { toast } from 'react-toastify';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import ConfirmDialog, { type ConfirmDialogOptions } from '@/@core/components/dialogs/ConfirmDialog';
 import { SectionBox } from '@/@core/components/filter-panel';
 import { ToolButton, ToolButtonSlot } from '@/@core/components/toolbar';
@@ -54,7 +55,7 @@ const BadnessSummaryReportPage = () => {
   // ** Hooks
   const { user }: any = useAuth();
   const ability = useContext(AbilityContext);
-  const isAdmin = user?.role === 'Admin';
+  const { isAdmin } = useRole();
 
   const { deleteBadnessIndividualById, resetAllBadnessRecords, summary }: any = badnessIndividualStore(
     (state: any) => ({

--- a/frontend/src/views/apps/reports/check-in/daily/CheckInDailyReportPage.tsx
+++ b/frontend/src/views/apps/reports/check-in/daily/CheckInDailyReportPage.tsx
@@ -39,6 +39,7 @@ import {
 import SidebarEditCheckInDrawer from '@/views/apps/reports/check-in/EditCheckInDrawer';
 import { shallow } from 'zustand/shallow';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import React from 'react';
 import { toApiDate } from '@/utils/datetime';
 
@@ -112,6 +113,7 @@ const DataGridCustom = styled(DataGrid)(({ theme }) => ({
 
 const CheckInDailyReportPage = () => {
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const router = useRouter();
 
@@ -181,7 +183,7 @@ const CheckInDailyReportPage = () => {
 
   // Authorization check
   useEffectOnce(() => {
-    if (!ability?.can('read', 'daily-check-in-report-activity-page') || (auth?.user?.role as string) === 'Admin') {
+    if (!ability?.can('read', 'daily-check-in-report-activity-page') || isAdmin) {
       router.push('/401');
       return;
     }
@@ -437,7 +439,7 @@ const CheckInDailyReportPage = () => {
 
   return (
     ability?.can('read', 'daily-check-in-report-activity-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/reports/check-in/summary/CheckInSummaryReportPage.tsx
+++ b/frontend/src/views/apps/reports/check-in/summary/CheckInSummaryReportPage.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation';
 import { BsBarChartLine } from 'react-icons/bs';
 import TableHeaderSummary from '@/views/apps/reports/check-in/TableHeaderSummary';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { shallow } from 'zustand/shallow';
 import { toast } from 'react-toastify';
 
@@ -22,6 +23,7 @@ interface CellType {
 const CheckInSummaryReportPage = () => {
   // ** Hooks
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const router = useRouter();
 
@@ -72,7 +74,7 @@ const CheckInSummaryReportPage = () => {
       });
     };
     // check permission
-    if (ability?.can('read', 'report-check-in-summary-page') && auth?.user?.role !== 'Admin') {
+    if (ability?.can('read', 'report-check-in-summary-page') && !isAdmin) {
       // check teacher on classroom
       if (isEmpty(auth?.user?.teacherOnClassroom)) {
         toast.error('ไม่พบข้อมูลที่ปรีกษาประจำชั้น');
@@ -365,7 +367,7 @@ const CheckInSummaryReportPage = () => {
 
   return (
     ability?.can('read', 'report-check-in-summary-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid size={12}>

--- a/frontend/src/views/apps/reports/goodness/all/GoodnessAllReportPage.tsx
+++ b/frontend/src/views/apps/reports/goodness/all/GoodnessAllReportPage.tsx
@@ -7,6 +7,7 @@ import { AbilityContext } from '@/layouts/components/acl/Can';
 import CloseIcon from '@mui/icons-material/Close';
 import TableHeader from '@/views/apps/reports/goodness/TableHeader';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import TimelineGoodness from '@/views/apps/student/view/TimelineGoodness';
 import { useGoodnessReport } from './hooks/useGoodnessReport';
 import { useGoodnessReportColumns } from './components/GoodnessReportColumns';
@@ -45,6 +46,7 @@ DialogCloseButton.displayName = 'DialogCloseButton';
 const GoodnessAllReportPage = () => {
   // ** Hooks
   const auth = useAuth();
+  const { isAdmin } = useRole();
   const ability = useContext(AbilityContext);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
@@ -103,7 +105,7 @@ const GoodnessAllReportPage = () => {
 
   return (
     ability?.can('read', 'report-goodness-page') &&
-    auth?.user?.role !== 'Admin' && (
+    !isAdmin && (
       <React.Fragment>
         <Box id='goodness-report-page' sx={{ borderRadius: '8px', overflow: 'hidden' }}>
           <Grid id='goodness-report-grid-container' container spacing={responsiveConfig.containerSpacing}>

--- a/frontend/src/views/apps/reports/goodness/summary/GoodnessSummaryReportPage.tsx
+++ b/frontend/src/views/apps/reports/goodness/summary/GoodnessSummaryReportPage.tsx
@@ -29,6 +29,7 @@ import { goodnessIndividualStore } from '@/store/index';
 import { shallow } from 'zustand/shallow';
 import { toast } from 'react-toastify';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import TimelineGoodness from '@/views/apps/student/view/TimelineGoodness';
 import ConfirmDialog, { type ConfirmDialogOptions } from '@/@core/components/dialogs/ConfirmDialog';
 import { SectionBox } from '@/@core/components/filter-panel';
@@ -54,7 +55,7 @@ const GoodnessSummaryReportPage = () => {
   // ** Hooks
   const { user }: any = useAuth();
   const ability = useContext(AbilityContext);
-  const isAdmin = user?.role === 'Admin';
+  const { isAdmin } = useRole();
 
   const { deleteGoodnessIndividualById, resetAllGoodnessRecords, summary }: any = goodnessIndividualStore(
     (state: any) => ({

--- a/frontend/src/views/apps/student/view/TimelineBadness.tsx
+++ b/frontend/src/views/apps/student/view/TimelineBadness.tsx
@@ -7,6 +7,7 @@ import { CircularProgress } from '@mui/material';
 import { calculateTimeAgo } from '@/utils/datetime';
 import useImageQuery from '@/hooks/useImageQuery';
 import IconifyIcon from '@/@core/components/icon';
+import { Roles } from '@/configs/roles';
 
 interface Props {
   info: any[];
@@ -127,7 +128,7 @@ const TimelineBadness = ({ info, user, onDeleted }: Props) => {
                       <Box sx={{ width: 200, height: 'auto' }}>
                         <ImageDisplay image={item?.image} />
                       </Box>
-                      {user?.role === 'Admin' && (
+                      {user?.role === Roles.Admin && (
                         <Box sx={{ ml: 2 }}>
                           <Tooltip title='ลบการบันทึกความประพฤติ'>
                             <Button

--- a/frontend/src/views/apps/student/view/TimelineGoodness.tsx
+++ b/frontend/src/views/apps/student/view/TimelineGoodness.tsx
@@ -14,6 +14,7 @@ import { TimelineConnector, TimelineContent, TimelineDot, TimelineItem, Timeline
 import { calculateTimeAgo } from '@/utils/datetime';
 import useImageQuery from '@/hooks/useImageQuery';
 import IconifyIcon from '@/@core/components/icon';
+import { Roles } from '@/configs/roles';
 
 interface Props {
   info: any[];
@@ -130,7 +131,7 @@ const TimelineGoodness = ({ info, user, onDeleted }: Props) => {
                       <Box sx={{ width: 200, height: 'auto' }}>
                         <ImageDisplay image={record?.image} />
                       </Box>
-                      {user?.role === 'Admin' && (
+                      {user?.role === Roles.Admin && (
                         <Box sx={{ ml: 2 }}>
                           <Tooltip title='ลบการบันทึกความดี'>
                             <Button

--- a/frontend/src/views/apps/teacher/list/hooks/useTeacherList.ts
+++ b/frontend/src/views/apps/teacher/list/hooks/useTeacherList.ts
@@ -3,6 +3,7 @@ import { useClassroomStore, useTeacherStore, useUserStore } from '@/store/index'
 import { useEffectOnce } from '@/hooks/userCommon';
 import { useResponsive } from '@/@core/hooks/useResponsive';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { shallow } from 'zustand/shallow';
 import { toast } from 'react-toastify';
 import { generateErrorMessages } from '@/utils/event';
@@ -45,7 +46,7 @@ export const useTeacherList = () => {
 
   // ** Hooks
   const { user } = useAuth();
-  const isAdmin = user?.role === 'Admin';
+  const { isAdmin } = useRole();
   const { isMobile } = useResponsive();
 
   const { resetPasswordByAdmin } = useUserStore(

--- a/frontend/src/views/pages/account-settings/AccountSettingsPage.tsx
+++ b/frontend/src/views/pages/account-settings/AccountSettingsPage.tsx
@@ -23,6 +23,7 @@ import TabSecurity from '@/views/pages/account-settings/TabSecurity';
 // ** Third Party Styles Imports
 import 'react-datepicker/dist/react-datepicker.css';
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import FallbackSpinner from '@/@core/components/spinner';
 import { isEmpty } from '@/@core/utils/utils';
 import React from 'react';
@@ -53,6 +54,7 @@ const AccountSettingsPage = () => {
 
   // Hooks
   const auth = useAuth();
+  const { isTeacher } = useRole();
   const handleChange = (event: SyntheticEvent, newValue: string) => {
     event.preventDefault();
     setValue(newValue);
@@ -89,7 +91,7 @@ const AccountSettingsPage = () => {
           <TabPanel sx={{ p: 0 }} value='account'>
             {isEmpty(auth?.user) ? (
               <FallbackSpinner />
-            ) : auth?.user?.role === 'Teacher' ? (
+            ) : isTeacher ? (
               <TabTeacherAccount />
             ) : (
               <TabAccount />

--- a/frontend/src/views/pages/home/HomePage.tsx
+++ b/frontend/src/views/pages/home/HomePage.tsx
@@ -4,13 +4,14 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 
 import AdminHomePage from './AdminHomePage';
 import TeacherHomePage from './TeacherHomePage';
 
 const HomePage = () => {
   const auth = useAuth();
-  const role = auth.user?.role?.toLowerCase();
+  const { isAdmin } = useRole();
 
   if (!auth.isInitialized || auth.loading) {
     return (
@@ -20,7 +21,7 @@ const HomePage = () => {
     );
   }
 
-  return role === 'admin' ? <AdminHomePage /> : <TeacherHomePage />;
+  return isAdmin ? <AdminHomePage /> : <TeacherHomePage />;
 };
 
 export default HomePage;

--- a/frontend/src/views/pages/home/TeacherHomePage.tsx
+++ b/frontend/src/views/pages/home/TeacherHomePage.tsx
@@ -60,6 +60,7 @@ import IconifyIcon from '@/@core/components/icon';
 
 // ** Hooks & Contexts
 import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
 import { useTeacherStudents } from '@/hooks/queries/useTeachers';
 import { useTeacherVisitStudents } from '@/hooks/queries/useVisits';
 import { useCheckInReportsByClassrooms } from '@/hooks/queries/useCheckIn';
@@ -161,10 +162,10 @@ const StarAvatar = styled(Avatar)(({ theme }) => ({
 
 const TeacherHomePage = () => {
   const auth = useAuth();
+  const { isAdmin, isTeacher } = useRole();
   const ability = useContext(AbilityContext);
   const router = useRouter();
   const theme = useTheme();
-  const isTeacher = auth.user?.role?.toLowerCase() === 'teacher';
 
   // ** States
   const [isMounted, setIsMounted] = useState<boolean>(false);
@@ -1008,7 +1009,7 @@ const TeacherHomePage = () => {
                           </span>
                         ) : (
                           <span>
-                            {auth?.user?.role === 'Admin'
+                            {isAdmin
                               ? 'ผู้ดูแลระบบ NKTC (ภาพรวมวิทยาลัย)'
                               : 'ครูผู้สอน / บุคลากรวิทยาลัยเทคนิคหนองคาย'}
                           </span>


### PR DESCRIPTION
## Summary

- Fix `ECONNREFUSED` on database connection in `backend-elysia`
- Root cause: passing external `pg.Pool` to `PrismaPg` fails `instanceof` check (different module instances — our `pg` vs adapter's nested `pg`) → adapter treats pool object as connection config → creates new pool with no credentials → connects `localhost` → refused
- Fix: pass raw connection config `{ connectionString, max, ... }` directly so adapter manages its own pool

## Test plan

- [ ] Start `backend-elysia` — confirm `✅ Database connected successfully` in logs
- [ ] Verify no `ECONNREFUSED` error on startup